### PR TITLE
test(api): Update tokio version due to security vulnerabilities in ActionController[#67]

### DIFF
--- a/src/player/actioncontroller/Cargo.toml
+++ b/src/player/actioncontroller/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 description = "Action Controller component for Pullpiri"
 
 [dependencies]
-tokio = { version = "1.36.0", features = ["full"] }
+tokio = { version = "1.45.0", features = ["full"] }
 tonic = "0.12.3"
 prost = "0.13.3"
 dbus = "0.9.7"


### PR DESCRIPTION
📝 PR Description
Update tokio from 1.35.0 to 1.45.0 due to security vulnerabilities

🔗 Related Issue
Closes https://github.com/eclipse-pullpiri/pullpiri/issues/67

🧪 Test Method
cargo deny check

📸 Screenshots
Cargo deny check output:
![image](https://github.com/user-attachments/assets/a46336a0-f965-4945-abde-09b19fcd04d8)

✅ Checklist
[✅] Code conventions are followed
[✅] Tests are added/modified
[✅] Documentation is updated (if necessary)