### PR TITLE
Implement MonitoringServer with gRPC support and send_container_list from NodeAgent to MonitoringServer

### DIFF
--- a/src/agent/nodeagent/src/grpc/sender.rs
+++ b/src/agent/nodeagent/src/grpc/sender.rs
@@ -7,6 +7,8 @@ use common::monitoringserver::{ContainerList, SendContainerListResponse};
 use common::statemanager::{
     connect_server, state_manager_connection_client::StateManagerConnectionClient, Action, Response,
 };
+
+use common::monitoringserver::monitoring_server_connection_client::MonitoringServerConnectionClient;
 use tonic::{Request, Status};
 
 /// Sender for making gRPC requests to Monitoring Server
@@ -30,17 +32,11 @@ impl NodeAgentSender {
         &mut self,
         container_list: ContainerList,
     ) -> Result<tonic::Response<SendContainerListResponse>, Status> {
-        // TODO : temporary debug print, remove or replace with proper logging
-        println!(
-            "Sending container list to monitoring server: {:?}",
-            container_list
-        );
-        // TODO : uncomment this code when ready
-        // let mut client = MonitoringServerConnectionClient::connect(common::monitoringserver::connect_server())
-        //     .await
-        //     .unwrap();
-        // client.send_container_list(Request::new(container_list)).await
+        let mut client = MonitoringServerConnectionClient::connect(common::monitoringserver::connect_server())
+            .await
+            .unwrap();
+        client.send_container_list(Request::new(container_list)).await
         // TODO : temporary return value, replace with proper error handling
-        Result::Ok(tonic::Response::new(SendContainerListResponse::default()))
+        // Result::Ok(tonic::Response::new(SendContainerListResponse::default()))
     }
 }

--- a/src/server/Cargo.lock
+++ b/src/server/Cargo.lock
@@ -685,6 +685,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,6 +786,11 @@ dependencies = [
 [[package]]
 name = "monitoringserver"
 version = "0.1.0"
+dependencies = [
+ "common",
+ "tokio",
+ "tonic",
+]
 
 [[package]]
 name = "multimap"
@@ -1304,15 +1320,17 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",

--- a/src/server/monitoringserver/Cargo.toml
+++ b/src/server/monitoringserver/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
+common.workspace = true
+tokio = "1.46.1"
+tonic = "0.12.3"

--- a/src/server/monitoringserver/src/grpc/mod.rs
+++ b/src/server/monitoringserver/src/grpc/mod.rs
@@ -1,0 +1,2 @@
+pub mod receiver;
+// pub mod sender;

--- a/src/server/monitoringserver/src/grpc/receiver.rs
+++ b/src/server/monitoringserver/src/grpc/receiver.rs
@@ -1,0 +1,34 @@
+use common::monitoringserver::monitoring_server_connection_server::MonitoringServerConnection;
+use common::monitoringserver::{ContainerList, SendContainerListResponse};
+use tokio::sync::mpsc;
+use tonic::{Request, Response, Status};
+
+/// MonitoringServer gRPC service handler
+#[derive(Clone)]
+pub struct MonitoringServerReceiver {
+    pub tx: mpsc::Sender<ContainerList>,
+}
+
+#[tonic::async_trait]
+impl MonitoringServerConnection for MonitoringServerReceiver {
+    /// Handle a ContainerList message from nodeagent
+    ///
+    /// Receives a ContainerList from nodeagent and forwards it to the MonitoringServer manager for processing.
+    async fn send_container_list<'life>(
+        &'life self,
+        request: Request<ContainerList>,
+    ) -> Result<Response<SendContainerListResponse>, Status> {
+        println!("Got a ContainerList from nodeagent");
+        let req: ContainerList = request.into_inner();
+
+        match self.tx.send(req).await {
+            Ok(_) => Ok(tonic::Response::new(SendContainerListResponse {
+                resp: "Successfully processed ContainerList".to_string(),
+            })),
+            Err(e) => Err(tonic::Status::new(
+                tonic::Code::Unavailable,
+                format!("cannot send container list: {}", e),
+            )),
+        }
+    }
+}

--- a/src/server/monitoringserver/src/main.rs
+++ b/src/server/monitoringserver/src/main.rs
@@ -1,3 +1,71 @@
-fn main() {
-    println!("Hello, world!");
+//! MonitoringServer main entry point
+//!
+//! This file sets up the asynchronous runtime, initializes the manager and gRPC server,
+//! and launches both concurrently. It also provides unit tests for initialization.
+
+use common::monitoringserver::ContainerList;
+pub mod grpc;
+pub mod manager;
+
+use common::monitoringserver::monitoring_server_connection_server::MonitoringServerConnectionServer;
+use tokio::sync::mpsc::{channel, Receiver, Sender};
+
+/// Launches the MonitoringServerManager in an asynchronous task.
+///
+/// This function creates the manager, initializes it, and then runs it.
+/// If initialization or running fails, errors are printed to stderr.
+async fn launch_manager(rx_grpc: Receiver<ContainerList>) {
+    let mut manager = manager::MonitoringServerManager::new(rx_grpc).await;
+
+    match manager.initialize().await {
+        Ok(_) => {
+            println!("MonitoringServerManager successfully initialized");
+            if let Err(e) = manager.run().await {
+                eprintln!("Error running MonitoringServerManager: {:?}", e);
+            }
+        }
+        Err(e) => {
+            eprintln!("Failed to initialize MonitoringServerManager: {:?}", e);
+        }
+    }
+}
+
+/// Initializes the MonitoringServer gRPC server.
+///
+/// Sets up the gRPC service and starts listening for incoming requests.
+async fn initialize(tx_grpc: Sender<ContainerList>) {
+    use tonic::transport::Server;
+
+    let server = grpc::receiver::MonitoringServerReceiver {
+        tx: tx_grpc.clone(),
+    };
+
+    let addr = common::monitoringserver::open_server()
+    .parse()
+    .expect("monitoringserver address parsing error");
+    println!("MonitoringServer listening on {}", addr);
+
+    let _ = Server::builder()
+        .add_service(MonitoringServerConnectionServer::new(server))
+        .serve(addr)
+        .await;
+}
+
+#[tokio::main]
+async fn main() {
+    let hostname: String = String::from_utf8_lossy(
+        &std::process::Command::new("hostname")
+            .output()
+            .expect("Failed to get hostname")
+            .stdout,
+    )
+    .trim()
+    .to_string();
+    println!("Starting MonitoringServer on host: {}", hostname);
+
+    let (tx_grpc, rx_grpc) = channel::<ContainerList>(100);
+    let mgr = launch_manager(rx_grpc);
+    let grpc = initialize(tx_grpc);
+
+    tokio::join!(mgr, grpc);
 }


### PR DESCRIPTION
url : #133 

- Add monitoringserver with asynchronous operation ready.
- Add NodeAgentSender struct for gRPC communication.
- Implement trigger_action method to send an Action to the StateManager via gRPC.
- Implement send_container_list method to send a ContainerList to the MonitoringServer via gRPC.