### PR TITLE
fix gRPC timing issue - #156

### DIFF
--- a/src/agent/nodeagent/src/bluechi/filemaker.rs
+++ b/src/agent/nodeagent/src/bluechi/filemaker.rs
@@ -172,7 +172,10 @@ containers:
         }
         // Remove the directory to force re-creation
         if std::path::Path::new(storage_dir).exists() {
-            std::fs::remove_dir_all(storage_dir).unwrap();
+            assert!(
+                std::fs::remove_dir_all(storage_dir).is_ok(),
+                "Failed to remove test directory"
+            );
         }
     }
 

--- a/src/agent/nodeagent/src/manager.rs
+++ b/src/agent/nodeagent/src/manager.rs
@@ -235,7 +235,7 @@ spec:
             yaml: yaml_string.clone(),
         };
 
-        tx.send(request).await.unwrap();
+        assert!(tx.send(request).await.is_ok());
         drop(tx);
 
         let result = manager.process_grpc_requests().await;

--- a/src/player/actioncontroller/src/grpc/sender/policymanager.rs
+++ b/src/player/actioncontroller/src/grpc/sender/policymanager.rs
@@ -37,6 +37,7 @@ pub async fn check_policy(scenario_name: String) -> Result<()> {
     let mut client = PolicyManagerConnectionClient::connect(addr)
         .await
         .map_err(|e| format!("Failed to connect to PolicyManager: {}", e))?;
+
     let request = tonic::Request::new(CheckPolicyRequest {
         scenario_name: scenario_name.clone(),
     }); // Clone scenario_name if needed later for error messages
@@ -95,7 +96,10 @@ pub async fn handle_yaml(workload_name: String) -> Result<bool> {
     }
 
     let addr = common::nodeagent::connect_server();
-    let mut client = NodeAgentConnectionClient::connect(addr).await.unwrap();
+    let mut client = NodeAgentConnectionClient::connect(addr)
+        .await //.unwrap();
+        .map_err(|e| format!("Failed to connect to NodeAgent: {}", e))?;
+
     let request = Request::new(HandleYamlRequest {
         yaml: workload_name,
     });

--- a/src/player/filtergateway/src/lib.rs
+++ b/src/player/filtergateway/src/lib.rs
@@ -10,12 +10,12 @@ pub use filter::Filter;
 pub use grpc::receiver::FilterGatewayReceiver;
 pub use grpc::sender::FilterGatewaySender;
 pub use manager::ScenarioParameter;
-use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tokio::sync::mpsc::{Receiver, Sender};
 pub use vehicle::dds::listener;
 pub use vehicle::dds::DdsData;
 pub use vehicle::dds::DdsTopicListener;
 pub async fn launch_manager(rx_grpc: Receiver<ScenarioParameter>) {
-    let mut manager = manager::FilterGatewayManager::new(rx_grpc).await;
+    let manager = manager::FilterGatewayManager::new(rx_grpc).await;
 
     match manager.initialize().await {
         Ok(_) => {

--- a/src/player/filtergateway/src/manager.rs
+++ b/src/player/filtergateway/src/manager.rs
@@ -77,7 +77,8 @@ impl FilterGatewayManager {
     pub async fn initialize(&self) -> Result<()> {
         println!("FilterGatewayManager init");
         // Initialize vehicle manager
-        let etcd_scenario = Self::read_all_scenario_from_etcd().await?;
+        let etcd_scenario = Self::read_all_scenario_from_etcd().await.unwrap_or_default();
+
         for scenario in etcd_scenario {
             let scenario: Scenario = serde_yaml::from_str(&scenario)?;
             println!("Scenario: {:?}", scenario);
@@ -100,6 +101,7 @@ impl FilterGatewayManager {
             }
             self.launch_scenario_filter(scenario).await?;
         }
+
         Ok(())
     }
 


### PR DESCRIPTION
## nodeagent
remove `unwrap()` in gRPC sender and do not send any container list if gRPC server is not available.
```
[ec2-user@ip-172-31-4-38 src]$ sudo podman logs -f piccolo-agent-nodeagent
Starting NodeAgent on host: HPC
NodeAgentManager init
NodeAgentManager successfully initialized
NodeAgent listening on 0.0.0.0:47004

thread 'tokio-runtime-worker' panicked at nodeagent/src/grpc/sender.rs:38:18:
called Result::unwrap() on an Err value: tonic::transport::Error(Transport, ConnectError(ConnectError("tcp connect error", Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })))
note: run with RUST_BACKTRACE=1 environment variable to display a backtrace
NodeAgentManager stopped
```

## filtergateway
If filtergateway cannot get any scenario info from etcd, return empty scenario instead of  `Err()`
```
[ec2-user@ip-172-31-4-38 yaml]$ sudo podman logs -f piccolo-player-filtergateway
FilterGatewayManager init
Piccolod gateway listening on 0.0.0.0:47002
Failed to initialize FilterGatewayManager: GRpcStatus(Status { code: Unavailable, message: "tcp connect error: Connection refused (os error 111)", source: Some(tonic::transport::Error(Transport, ConnectError(ConnectError("tcp connect error", Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })))) })
```