### PR TITLE
feat(api): Add state machine foundation for PICCOLO resource state management[#204]

### DIFF
--- a/src/player/statemanager/Cargo.toml
+++ b/src/player/statemanager/Cargo.toml
@@ -14,3 +14,4 @@ license = "Apache-2.0"
 common.workspace = true
 tokio = "1.43.1"
 tonic = "0.12.3"
+chrono = { version = "0.4", features = ["serde"] }

--- a/src/player/statemanager/src/main.rs
+++ b/src/player/statemanager/src/main.rs
@@ -21,6 +21,7 @@ use tonic::transport::Server;
 
 pub mod grpc;
 pub mod manager;
+pub mod state_machine;
 
 /// Launches the StateManagerManager in an asynchronous task.
 ///

--- a/src/player/statemanager/src/mod.rs
+++ b/src/player/statemanager/src/mod.rs
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2024 LG Electronics Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! StateManager Module Exports
+//!
+//! This module provides the public interface for the StateManager component
+
+pub mod grpc;
+pub mod manager;
+pub mod state_machine;
+
+// Re-export main types for easier access
+pub use manager::StateManagerManager;
+pub use state_machine::{StateMachine, TransitionResult, ResourceState};

--- a/src/player/statemanager/src/state_machine.rs
+++ b/src/player/statemanager/src/state_machine.rs
@@ -1,0 +1,455 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2024 LG Electronics Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! State Machine Implementation for PICCOLO Resource State Management
+//!
+//! This module implements the core state transition logic for Scenario, Package, and Model resources
+//! according to the PICCOLO specification. It provides efficient data structures and algorithms
+//! for managing state changes and enforcing the defined state transition tables.
+//!
+//! # Architecture Overview
+//!
+//! The state machine follows a table-driven approach where each resource type (Scenario, Package, Model)
+//! has its own transition table defining valid state changes. The system supports:
+//! - Conditional transitions based on resource state
+//! - Action execution during state changes
+//! - Health monitoring and failure handling
+//! - Backoff mechanisms for failed transitions
+//!
+//! # Usage Example
+//!
+//! ```rust
+//! let mut state_machine = StateMachine::new();
+//! let state_change = StateChange { /* ... */ };
+//! let result = state_machine.process_state_change(state_change);
+//! ```
+
+use common::statemanager::{ResourceType, StateChange, ErrorCode};
+use std::collections::HashMap;
+use tokio::time::{Duration, Instant};
+
+/// Represents a single state transition rule in the state machine
+///
+/// Each transition defines a complete rule for moving from one state to another,
+/// including optional conditions that must be met and actions to execute.
+///
+/// # Fields
+/// - `from_state`: The source state that must be current for this transition to apply
+/// - `event`: The trigger event that initiates this transition
+/// - `to_state`: The target state after successful transition
+/// - `condition`: Optional condition that must evaluate to true (e.g., "resource_count > 0")
+/// - `action`: Action to execute during transition (e.g., "start_container", "cleanup_resources")
+#[derive(Debug, Clone, PartialEq)]
+pub struct StateTransition {
+    pub from_state: String,
+    pub event: String,
+    pub to_state: String,
+    pub condition: Option<String>,
+    pub action: String,
+}
+
+/// Tracks the complete state information for a managed resource
+///
+/// This structure maintains both current state and metadata necessary for
+/// state management decisions, health monitoring, and audit trails.
+///
+/// # Fields
+/// - `resource_type`: The type of resource (Scenario, Package, or Model)
+/// - `resource_name`: Unique identifier for the resource instance
+/// - `current_state`: Current operational state of the resource
+/// - `desired_state`: Target state the resource should transition to (if any)
+/// - `last_transition_time`: Timestamp of the most recent state change
+/// - `transition_count`: Total number of state transitions for this resource
+/// - `metadata`: Key-value pairs for additional resource information
+/// - `health_status`: Current health and monitoring information
+#[derive(Debug, Clone)]
+pub struct ResourceState {
+    pub resource_type: ResourceType,
+    pub resource_name: String,
+    pub current_state: String,
+    pub desired_state: Option<String>,
+    pub last_transition_time: Instant,
+    pub transition_count: u64,
+    pub metadata: HashMap<String, String>,
+    pub health_status: HealthStatus,
+}
+
+/// Comprehensive health monitoring information for resources
+///
+/// Tracks the operational health of resources to enable proactive
+/// failure detection and recovery mechanisms.
+///
+/// # Fields
+/// - `healthy`: Overall health status indicator
+/// - `status_message`: Human-readable description of current health state
+/// - `last_check`: Timestamp of the most recent health evaluation
+/// - `consecutive_failures`: Counter for consecutive failed health checks (used for backoff)
+#[derive(Debug, Clone)]
+pub struct HealthStatus {
+    pub healthy: bool,
+    pub status_message: String,
+    pub last_check: Instant,
+    pub consecutive_failures: u32,
+}
+
+/// Comprehensive result of a state transition attempt
+///
+/// Provides detailed information about transition outcomes, including
+/// success status, resulting state, error details, and follow-up actions.
+///
+/// # Fields
+/// - `success`: Whether the transition completed successfully
+/// - `new_state`: The resulting state after transition attempt
+/// - `error_code`: Specific error classification for failures
+/// - `message`: Human-readable description of the result
+/// - `actions_to_execute`: List of actions that should be performed post-transition
+#[derive(Debug, Clone)]
+pub struct TransitionResult {
+    pub success: bool,
+    pub new_state: String,
+    pub error_code: ErrorCode,
+    pub message: String,
+    pub actions_to_execute: Vec<String>,
+}
+
+/// Core state machine implementation for PICCOLO resource management
+///
+/// This is the central component that manages all resource state transitions,
+/// enforces business rules, and maintains the current state of all resources
+/// in the system.
+///
+/// # Design Principles
+/// - **Deterministic**: Same inputs always produce same outputs
+/// - **Auditable**: All state changes are tracked with timestamps
+/// - **Resilient**: Handles failures gracefully with backoff mechanisms
+/// - **Extensible**: New resource types can be added with their own transition tables
+///
+/// # Thread Safety
+/// This implementation is not thread-safe. External synchronization is required
+/// for concurrent access across multiple threads.
+pub struct StateMachine {
+    /// State transition tables indexed by resource type
+    /// 
+    /// Each resource type has its own set of valid transitions, allowing
+    /// for type-specific state management rules and behaviors.
+    transition_tables: HashMap<ResourceType, Vec<StateTransition>>,
+    
+    /// Current state tracking for all managed resources
+    /// 
+    /// Resources are keyed by a unique identifier (typically resource name)
+    /// and contain complete state information including metadata and health status.
+    resource_states: HashMap<String, ResourceState>,
+    
+    /// Backoff timers for CrashLoopBackOff and retry management
+    /// 
+    /// Tracks when resources that have failed transitions can be retried,
+    /// implementing exponential backoff to prevent resource thrashing.
+    backoff_timers: HashMap<String, Instant>,
+}
+
+impl StateMachine {
+    /// Creates a new StateMachine with predefined transition tables
+    ///
+    /// Initializes the state machine with empty resource tracking and
+    /// populates the transition tables for all supported resource types.
+    ///
+    /// # Returns
+    /// A fully configured StateMachine ready to process state changes
+    ///
+    /// # Examples
+    /// ```rust
+    /// let state_machine = StateMachine::new();
+    /// ```
+    pub fn new() -> Self {
+        let mut state_machine = StateMachine {
+            transition_tables: HashMap::new(),
+            resource_states: HashMap::new(),
+            backoff_timers: HashMap::new(),
+        };
+
+        // Initialize transition tables for each resource type according to PICCOLO specification
+        state_machine.initialize_scenario_transitions();
+        state_machine.initialize_package_transitions();
+        state_machine.initialize_model_transitions();
+
+        state_machine
+    }
+
+    /// Initialize the state transition table for Scenario resources
+    ///
+    /// Populates the transition table with all valid state changes for Scenario resources
+    /// according to the PICCOLO specification. This includes transitions for:
+    /// - Creation and initialization
+    /// - Activation and deactivation
+    /// - Error handling and recovery
+    /// - Cleanup and termination
+    ///
+    /// # Implementation Note
+    /// This method should define transitions like:
+    /// - "Inactive" -> "Active" on "activate" event
+    /// - "Active" -> "Inactive" on "deactivate" event
+    /// - Any state -> "Failed" on "error" event
+    fn initialize_scenario_transitions(&mut self) {
+        todo!()
+    }
+
+    /// Initialize the state transition table for Package resources
+    ///
+    /// Configures all valid state transitions for Package resources, including:
+    /// - Download and installation states
+    /// - Verification and validation phases
+    /// - Update and rollback mechanisms
+    /// - Cleanup and removal operations
+    ///
+    /// # Implementation Note
+    /// Package transitions typically involve more complex workflows due to
+    /// dependency management and rollback requirements.
+    fn initialize_package_transitions(&mut self) {
+        todo!()
+    }
+
+    /// Initialize the state transition table for Model resources
+    ///
+    /// Sets up state transitions specific to Model resources, covering:
+    /// - Model loading and initialization
+    /// - Training and inference states
+    /// - Model versioning and updates
+    /// - Resource allocation and cleanup
+    ///
+    /// # Implementation Note
+    /// Model transitions may include resource-intensive operations and
+    /// should account for memory and compute constraints.
+    fn initialize_model_transitions(&mut self) {
+        todo!()
+    }
+
+    /// Process a state change request and return the comprehensive result
+    ///
+    /// This is the main entry point for all state transitions. It validates the request,
+    /// checks transition rules, evaluates conditions, and executes the state change
+    /// if valid.
+    ///
+    /// # Parameters
+    /// - `state_change`: The requested state change containing resource info and target state
+    ///
+    /// # Returns
+    /// A `TransitionResult` containing the outcome and any required follow-up actions
+    ///
+    /// # Processing Steps
+    /// 1. Validate and convert resource type from the request
+    /// 2. Determine current state (from existing resource or request for new resources)
+    /// 3. Check for special conditions (e.g., CrashLoopBackOff timing)
+    /// 4. Find and validate the requested transition
+    /// 5. Evaluate any conditional requirements
+    /// 6. Execute the transition and update resource state
+    /// 7. Schedule any required follow-up actions
+    ///
+    /// # Error Handling
+    /// - Invalid resource types return appropriate error codes
+    /// - Failed condition evaluations are logged with details
+    /// - Transition failures trigger backoff mechanisms where appropriate
+    pub fn process_state_change(&mut self, state_change: StateChange) -> TransitionResult {
+        // Convert i32 to ResourceType enum - validate input format
+        // Get current state - use provided current_state for new resources
+        // For new resources, use the current_state from the StateChange message
+        // This allows proper state transitions for resources that don't exist yet
+        // Check for special CrashLoopBackOff handling - prevent rapid retry cycles
+        // Find valid transition - ensure the requested change is allowed
+        // Execute transition - perform the actual state change and update tracking
+        todo!()
+    }
+
+    /// Find a valid transition rule for the given parameters
+    ///
+    /// Searches the appropriate transition table for a rule that matches
+    /// the specified resource type, current state, event, and target state.
+    ///
+    /// # Parameters
+    /// - `resource_type`: The type of resource to check transitions for
+    /// - `from_state`: The current state of the resource
+    /// - `event`: The event triggering the transition
+    /// - `to_state`: The desired target state
+    ///
+    /// # Returns
+    /// - `Some(StateTransition)`: If a valid transition rule is found
+    /// - `None`: If no valid transition exists for the given parameters
+    ///
+    /// # Implementation Details
+    /// This method performs exact matching on all transition parameters.
+    /// Wildcard or pattern matching is not currently supported.
+    fn find_valid_transition(
+        &self,
+        resource_type: ResourceType,
+        from_state: &str,
+        event: &str,
+        to_state: &str,
+    ) -> Option<StateTransition> {
+        todo!()
+    }
+
+    /// Infer the appropriate event type from state transition
+    ///
+    /// When an explicit event is not provided, this method attempts to
+    /// determine the most appropriate event based on the current and target states.
+    ///
+    /// # Parameters
+    /// - `current_state`: The current state of the resource
+    /// - `target_state`: The desired target state
+    ///
+    /// # Returns
+    /// A string representing the inferred event type
+    ///
+    /// # Examples
+    /// - "Inactive" -> "Active" might infer "activate"
+    /// - "Running" -> "Stopped" might infer "stop"
+    /// - Any state -> "Failed" might infer "error"
+    ///
+    /// # Fallback Behavior
+    /// If no specific event can be inferred, returns a generic event name
+    /// based on the target state (e.g., "transition_to_active").
+    fn infer_event_from_states(&self, current_state: &str, target_state: &str) -> String {
+        todo!()
+    }
+
+    /// Evaluate whether a transition condition is satisfied
+    ///
+    /// Processes conditional logic attached to state transitions to determine
+    /// if the transition should be allowed to proceed.
+    ///
+    /// # Parameters
+    /// - `condition`: The condition string to evaluate (e.g., "resource_count > 0")
+    /// - `_state_change`: The state change request providing context for evaluation
+    ///
+    /// # Returns
+    /// - `true`: If the condition is satisfied or no condition exists
+    /// - `false`: If the condition fails evaluation
+    ///
+    /// # Supported Conditions
+    /// The condition language should support:
+    /// - Resource property comparisons
+    /// - Metadata key existence checks
+    /// - Numeric and string comparisons
+    /// - Boolean logic operators
+    ///
+    /// # Error Handling
+    /// Malformed conditions should be logged and default to `false` for safety.
+    fn evaluate_condition(&self, condition: &str, _state_change: &StateChange) -> bool {
+        todo!()
+    }
+
+    /// Validate if a state is appropriate for resource initialization
+    ///
+    /// Checks whether the specified state is a valid starting point for
+    /// a new resource of the given type.
+    ///
+    /// # Parameters
+    /// - `resource_type`: The type of resource being created
+    /// - `state`: The proposed initial state
+    ///
+    /// # Returns
+    /// - `true`: If the state is a valid initial state for the resource type
+    /// - `false`: If the state is not appropriate for new resource creation
+    ///
+    /// # Design Rationale
+    /// Not all states are appropriate for resource creation. For example,
+    /// a resource should not be created directly in a "Failed" state.
+    fn is_valid_initial_state(&self, resource_type: ResourceType, state: &str) -> bool {
+        todo!()
+    }
+
+    /// Update the internal resource state after a successful transition
+    ///
+    /// Performs all necessary bookkeeping when a state transition succeeds,
+    /// including updating timestamps, incrementing counters, and managing metadata.
+    ///
+    /// # Parameters
+    /// - `resource_key`: Unique identifier for the resource
+    /// - `state_change`: The original state change request
+    /// - `new_state`: The state the resource has transitioned to
+    /// - `resource_type`: The type of the resource
+    ///
+    /// # Side Effects
+    /// - Updates or creates the resource state entry
+    /// - Increments transition counter
+    /// - Updates last transition timestamp
+    /// - Clears any active backoff timers on successful transition
+    /// - Updates health status if applicable
+    fn update_resource_state(&mut self, resource_key: &str, state_change: &StateChange, new_state: &str, resource_type: ResourceType) {
+        todo!()
+    }
+
+    /// Retrieve the current state information for a specific resource
+    ///
+    /// Provides read-only access to the complete state information for
+    /// a resource, including metadata and health status.
+    ///
+    /// # Parameters
+    /// - `resource_name`: The unique name of the resource
+    /// - `resource_type`: The type of the resource (for validation)
+    ///
+    /// # Returns
+    /// - `Some(&ResourceState)`: If the resource exists and types match
+    /// - `None`: If the resource doesn't exist or type mismatch
+    ///
+    /// # Usage
+    /// This method is primarily used for:
+    /// - Status queries from external systems
+    /// - Health check implementations
+    /// - Audit and monitoring purposes
+    pub fn get_resource_state(&self, resource_name: &str, resource_type: ResourceType) -> Option<&ResourceState> {
+        todo!()
+    }
+
+    /// List all resources currently in a specific state
+    ///
+    /// Provides a filtered view of all managed resources based on their
+    /// current state, optionally filtered by resource type.
+    ///
+    /// # Parameters
+    /// - `resource_type`: Optional filter for resource type (None = all types)
+    /// - `state`: The state to filter by
+    ///
+    /// # Returns
+    /// A vector of references to all matching resource states
+    ///
+    /// # Performance Note
+    /// This method performs a linear scan of all resources. For large numbers
+    /// of resources, consider implementing indexed lookups by state.
+    ///
+    /// # Usage Examples
+    /// - Find all failed resources: `list_resources_by_state(None, "Failed")`
+    /// - Find active scenarios: `list_resources_by_state(Some(ResourceType::Scenario), "Active")`
+    pub fn list_resources_by_state(&self, resource_type: Option<ResourceType>, state: &str) -> Vec<&ResourceState> {
+        todo!()
+    }
+
+    /// Convert ResourceType enum to string representation for logging
+    ///
+    /// Provides consistent string representation of resource types for
+    /// logging, debugging, and external API responses.
+    ///
+    /// # Parameters
+    /// - `resource_type`: The resource type to convert
+    ///
+    /// # Returns
+    /// A static string slice representing the resource type
+    ///
+    /// # Design Note
+    /// Using static string slices avoids unnecessary string allocations
+    /// for this frequently-called utility function.
+    fn resource_type_to_string(&self, resource_type: ResourceType) -> &'static str {
+        todo!()
+    }
+}
+
+/// Default implementation that creates a new StateMachine
+///
+/// Provides a convenient way to create a StateMachine with default
+/// configuration using the `Default` trait.
+impl Default for StateMachine {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/player/statemanager/src/state_machine.rs
+++ b/src/player/statemanager/src/state_machine.rs
@@ -105,13 +105,18 @@ pub struct HealthStatus {
 /// - `error_code`: Specific error classification for failures
 /// - `message`: Human-readable description of the result
 /// - `actions_to_execute`: List of actions that should be performed post-transition
+/// - `transition_id`: Unique identifier for the transition attempt
+/// - `error_details`: Detailed error information (if any)
+
+/// Result of a state transition attempt - aligned with proto StateChangeResponse
 #[derive(Debug, Clone)]
 pub struct TransitionResult {
-    pub success: bool,
     pub new_state: String,
     pub error_code: ErrorCode,
     pub message: String,
     pub actions_to_execute: Vec<String>,
+    pub transition_id: String,
+    pub error_details: String,
 }
 
 /// Core state machine implementation for PICCOLO resource management


### PR DESCRIPTION
📝 PR Description
feat(api): Add state machine foundation for PICCOLO resource state management[#204]
Implements core data structures and method signatures for managing state transitions of Scenario, Package, and Model resources with comprehensive documentation and TODO placeholders for implementation.

🔗 Related Issue
In Progress-> https://github.com/eclipse-pullpiri/pullpiri/issues/204

🧪 Test Method
**Run statemanager by:**
sudo cargo run  --->In progress

✅ Checklist
[✅] Code conventions are followed
[✅] Tests are added/modified
[✅] Documentation is updated (if necessary)