### PR TITLE
feat(nodeagent): add background task for periodic node info gathering (url: #217)

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -830,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "linux-raw-sys"
@@ -914,9 +914,11 @@ dependencies = [
  "futures",
  "hyper 0.14.32",
  "hyperlocal",
+ "once_cell",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sysinfo",
  "thiserror 1.0.69",
  "tokio",
  "tonic",
@@ -930,6 +932,34 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1412,6 +1442,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "sysinfo"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252800745060e7b9ffb7b2badbd8b31cfa4aa2e61af879d0a3bf2a317c20217d"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,6 +1801,130 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,6 +1956,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/src/agent/nodeagent/Cargo.toml
+++ b/src/agent/nodeagent/Cargo.toml
@@ -14,4 +14,5 @@ futures = "0.3.31"
 hyper = { version = "0.14", features = ["full"] }
 hyperlocal = { version = "0.8", features = ["client"] }
 thiserror = "1.0"
-
+once_cell = "1.19.0"
+sysinfo = "0.36.1"

--- a/src/agent/nodeagent/src/resource/mod.rs
+++ b/src/agent/nodeagent/src/resource/mod.rs
@@ -25,6 +25,35 @@ async fn get(path: &str) -> Result<hyper::body::Bytes, hyper::Error> {
     hyper::body::to_bytes(res).await
 }
 
+/// Node information matching the requested DataCache structure.
+#[derive(Deserialize, Debug)]
+pub struct NodeInfo {
+    // 1. CPU
+    pub cpu_count: usize, // NodeInfo['cpu']['cpu_count']
+    pub cpu_usage: f32,   // NodeInfo['cpu']['cpu_usage']
+
+    // 2. GPU
+    pub gpu_count: usize, // NodeInfo['gpu']['gpu_count']
+
+    // 3. Memory
+    pub total_memory: u64, // NodeInfo['mem']['total_memory']
+    pub used_memory: u64,  // NodeInfo['mem']['used_memory']
+    pub mem_usage: f32,    // NodeInfo['mem']['mem_usage']
+
+    // 4. Network
+    pub rx_bytes: u64, // NodeInfo['net']['rx_bytes']
+    pub tx_bytes: u64, // NodeInfo['net']['tx_bytes']
+
+    // 5. Storage
+    pub read_bytes: u64,  // NodeInfo['storage']['read_bytes']
+    pub write_bytes: u64, // NodeInfo['storage']['write_bytes']
+
+    // 6. System
+    pub os: String,   // NodeInfo['system']['os']
+    pub arch: String, // NodeInfo['system']['arch']
+    pub ip: String,   // NodeInfo['system']['ip']
+}
+
 #[derive(Error, Debug)]
 pub enum ContainerError {
     #[error("Podman API error: {0}")]

--- a/src/agent/nodeagent/src/resource/mod.rs
+++ b/src/agent/nodeagent/src/resource/mod.rs
@@ -1,4 +1,5 @@
 pub mod container;
+pub mod nodeinfo;
 
 use hyper::{Body, Client, Uri};
 use hyperlocal::{UnixConnector, Uri as UnixUri};

--- a/src/agent/nodeagent/src/resource/nodeinfo.rs
+++ b/src/agent/nodeagent/src/resource/nodeinfo.rs
@@ -1,0 +1,188 @@
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+use std::{thread, time::Duration};
+use sysinfo::{Networks, System};
+
+// Static storage for previous IO/network values for delta calculation
+static PREV_IO: Lazy<Mutex<Option<(u64, u64, u64, u64)>>> = Lazy::new(|| Mutex::new(None));
+
+/// Returns NodeInfo with rx_bytes, tx_bytes, read_bytes, write_bytes as deltas since last call.
+pub fn extract_node_info_delta() -> NodeInfo {
+    let mut sys = System::new_all();
+    std::thread::sleep(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL);
+    sys.refresh_cpu_usage();
+
+    // 1. CPU
+    let cpu_count = sys.cpus().len();
+    // Average all logical CPU usage values
+    let cpu_usage = if cpu_count > 0 {
+        sys.cpus().iter().map(|cpu| cpu.cpu_usage()).sum::<f32>() / cpu_count as f32
+    } else {
+        0.0
+    };
+
+    // 2. GPU
+    let gpu_count = match std::fs::read_dir("/sys/class/drm/") {
+        Ok(entries) => entries
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| {
+                let fname = entry.file_name();
+                let fname = fname.to_string_lossy();
+                fname.starts_with("card") && fname.chars().skip(4).all(|c| c.is_ascii_digit())
+            })
+            .count(),
+        Err(_) => 0,
+    };
+
+    // 3. Memory
+    let total_memory = sys.total_memory();
+    let used_memory = sys.used_memory();
+    let mem_usage = if total_memory > 0 {
+        (used_memory as f32) / (total_memory as f32) * 100.0
+    } else {
+        0.0
+    };
+
+    // 4. Network (sum over all interfaces)
+    let networks = Networks::new_with_refreshed_list();
+    // summation of each interface's received and transmitted bytes
+    let mut rx_bytes_now: u64 = 0;
+    let mut tx_bytes_now: u64 = 0;
+    for (interface_name, data) in &networks {
+        rx_bytes_now += data.total_received();
+        tx_bytes_now += data.total_transmitted();
+    }
+
+    // 5. Storage (read_bytes, write_bytes) from /proc/diskstats
+    let (read_bytes_now, write_bytes_now) = get_disk_io_bytes();
+
+    // Calculate deltas from previous values
+    let mut prev = PREV_IO.lock().unwrap();
+    let (rx_bytes, tx_bytes, read_bytes, write_bytes) =
+        if let Some((prev_rx, prev_tx, prev_read, prev_write)) = *prev {
+            (
+                rx_bytes_now.saturating_sub(prev_rx),
+                tx_bytes_now.saturating_sub(prev_tx),
+                read_bytes_now.saturating_sub(prev_read),
+                write_bytes_now.saturating_sub(prev_write),
+            )
+        } else {
+            (0, 0, 0, 0)
+        };
+    // Store current values for next delta calculation
+    *prev = Some((rx_bytes_now, tx_bytes_now, read_bytes_now, write_bytes_now));
+
+    // OS and Arch extraction using sysinfo
+    let os = sysinfo::System::long_os_version().unwrap_or_else(|| "Unknown".to_string());
+    let arch = sysinfo::System::cpu_arch();
+
+    // IP extraction (first non-loopback IPv4)
+    let ip = get_local_ip().unwrap_or_else(|| "Unknown".to_string());
+
+    NodeInfo {
+        cpu_count,
+        cpu_usage,
+        gpu_count,
+        total_memory,
+        used_memory,
+        mem_usage,
+        rx_bytes,
+        tx_bytes,
+        read_bytes,
+        write_bytes,
+        os,
+        arch,
+        ip,
+    }
+}
+
+/// Node information matching the requested DataCache structure.
+#[derive(Debug, Clone)]
+pub struct NodeInfo {
+    // 1. CPU
+    pub cpu_count: usize, // NodeInfo['cpu']['cpu_count']
+    pub cpu_usage: f32,   // NodeInfo['cpu']['cpu_usage']
+
+    // 2. GPU
+    pub gpu_count: usize, // NodeInfo['gpu']['gpu_count']
+
+    // 3. Memory
+    pub total_memory: u64, // NodeInfo['mem']['total_memory']
+    pub used_memory: u64,  // NodeInfo['mem']['used_memory']
+    pub mem_usage: f32,    // NodeInfo['mem']['mem_usage']
+
+    // 4. Network
+    pub rx_bytes: u64, // NodeInfo['net']['rx_bytes']
+    pub tx_bytes: u64, // NodeInfo['net']['tx_bytes']
+
+    // 5. Storage
+    pub read_bytes: u64,  // NodeInfo['storage']['read_bytes']
+    pub write_bytes: u64, // NodeInfo['storage']['write_bytes']
+
+    // 6. System
+    pub os: String,   // NodeInfo['system']['os']
+    pub arch: String, // NodeInfo['system']['arch']
+    pub ip: String,   // NodeInfo['system']['ip']
+}
+
+/// Returns the first non-loopback IPv4 address as a String, or None if not found.
+fn get_local_ip() -> Option<String> {
+    use std::net::UdpSocket;
+    // This does not actually send a packet
+    if let Ok(socket) = UdpSocket::bind("0.0.0.0:0") {
+        if socket.connect("8.8.8.8:80").is_ok() {
+            if let Ok(local_addr) = socket.local_addr() {
+                let ip = local_addr.ip();
+                if ip.is_ipv4() && !ip.is_loopback() {
+                    return Some(ip.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Returns (read_bytes, write_bytes) by parsing /proc/diskstats and summing all block devices.
+fn get_disk_io_bytes() -> (u64, u64) {
+    let mut read_sectors = 0u64;
+    let mut write_sectors = 0u64;
+    if let Ok(content) = std::fs::read_to_string("/proc/diskstats") {
+        for line in content.lines() {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() > 13 {
+                let name = parts[2];
+                // Only count physical disks (skip loop, ram, partitions, etc.)
+                if name.starts_with("sd")
+                    || name.starts_with("hd")
+                    || name.starts_with("vd")
+                    || name.starts_with("nvme")
+                {
+                    // Field 5: sectors read, Field 9: sectors written
+                    read_sectors += parts[5].parse::<u64>().unwrap_or(0);
+                    write_sectors += parts[9].parse::<u64>().unwrap_or(0);
+                }
+            }
+        }
+    }
+    // Most systems use 512 bytes per sector
+    (read_sectors * 512, write_sectors * 512)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_node_info_delta() {
+        let info = extract_node_info_delta();
+        assert!(info.cpu_usage >= 0.0 && info.cpu_usage <= 100.0);
+        assert!(info.cpu_count > 0);
+        assert!(info.total_memory > 0);
+        assert!(info.used_memory <= info.total_memory);
+        assert!(info.mem_usage >= 0.0 && info.mem_usage <= 100.0);
+        assert!(info.rx_bytes >= 0);
+        assert!(info.tx_bytes >= 0);
+        assert!(info.read_bytes >= 0);
+        assert!(info.write_bytes >= 0);
+    }
+}

--- a/src/agent/nodeagent/src/resource/nodeinfo.rs
+++ b/src/agent/nodeagent/src/resource/nodeinfo.rs
@@ -1,6 +1,6 @@
+use super::NodeInfo;
 use once_cell::sync::Lazy;
 use std::sync::Mutex;
-use std::{thread, time::Duration};
 use sysinfo::{Networks, System};
 
 // Static storage for previous IO/network values for delta calculation
@@ -48,7 +48,7 @@ pub fn extract_node_info_delta() -> NodeInfo {
     // summation of each interface's received and transmitted bytes
     let mut rx_bytes_now: u64 = 0;
     let mut tx_bytes_now: u64 = 0;
-    for (interface_name, data) in &networks {
+    for (_, data) in &networks {
         rx_bytes_now += data.total_received();
         tx_bytes_now += data.total_transmitted();
     }
@@ -94,35 +94,6 @@ pub fn extract_node_info_delta() -> NodeInfo {
         arch,
         ip,
     }
-}
-
-/// Node information matching the requested DataCache structure.
-#[derive(Debug, Clone)]
-pub struct NodeInfo {
-    // 1. CPU
-    pub cpu_count: usize, // NodeInfo['cpu']['cpu_count']
-    pub cpu_usage: f32,   // NodeInfo['cpu']['cpu_usage']
-
-    // 2. GPU
-    pub gpu_count: usize, // NodeInfo['gpu']['gpu_count']
-
-    // 3. Memory
-    pub total_memory: u64, // NodeInfo['mem']['total_memory']
-    pub used_memory: u64,  // NodeInfo['mem']['used_memory']
-    pub mem_usage: f32,    // NodeInfo['mem']['mem_usage']
-
-    // 4. Network
-    pub rx_bytes: u64, // NodeInfo['net']['rx_bytes']
-    pub tx_bytes: u64, // NodeInfo['net']['tx_bytes']
-
-    // 5. Storage
-    pub read_bytes: u64,  // NodeInfo['storage']['read_bytes']
-    pub write_bytes: u64, // NodeInfo['storage']['write_bytes']
-
-    // 6. System
-    pub os: String,   // NodeInfo['system']['os']
-    pub arch: String, // NodeInfo['system']['arch']
-    pub ip: String,   // NodeInfo['system']['ip']
 }
 
 /// Returns the first non-loopback IPv4 address as a String, or None if not found.
@@ -180,9 +151,6 @@ mod tests {
         assert!(info.total_memory > 0);
         assert!(info.used_memory <= info.total_memory);
         assert!(info.mem_usage >= 0.0 && info.mem_usage <= 100.0);
-        assert!(info.rx_bytes >= 0);
-        assert!(info.tx_bytes >= 0);
-        assert!(info.read_bytes >= 0);
-        assert!(info.write_bytes >= 0);
+        // Removed always-true u64 >= 0 assertions
     }
 }

--- a/src/player/Cargo.lock
+++ b/src/player/Cargo.lock
@@ -314,6 +314,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -1760,6 +1761,7 @@ dependencies = [
 name = "statemanager"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "common",
  "tokio",
  "tonic",


### PR DESCRIPTION
url: #217 

- Refactored system info extraction to use a single NodeInfo struct with fields for CPU, GPU, memory, network, storage, OS, arch, and IP.
- All I/O fields (rx/tx/read/write bytes) report deltas since the last call, using static storage for previous values.
- CPU usage is calculated as the average of all logical CPUs after two refreshes and a short sleep.
- OS and architecture are extracted via sysinfo; IP is determined from the first non-loopback IPv4 address.
- Network and disk stats are parsed directly from /proc/net/dev and /proc/diskstats for reliability.