### PR TITLE
feat(api)-release nodeagent binary on release page[#228]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,13 @@ jobs:
           name: license-report
           path: dist/licenses/
 
+      # Download nodeagent binary
+      - name: Download nodeagent binary
+        uses: actions/download-artifact@v4
+        with:
+          name: nodeagent-binary
+          path: dist/binaries/
+
       # Upload all reports as GitHub Release assets
 
       # Optional: upload coverage for player component
@@ -238,6 +245,16 @@ jobs:
           file: doc-archive.tar.gz
           tag: ${{ github.ref }}
       
+      # Upload nodeagent binary to release
+      - name: Upload nodeagent binary (Linux AMD64) to release
+        uses: svenstaro/upload-release-action@v2
+        id: upload_nodeagent_amd64
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dist/binaries/nodeagent-linux-amd64
+          asset_name: nodeagent-linux-amd64
+          tag: ${{ github.ref }}
+      
       # Fetch latest release metadata (used by quality manifest tool)
       - name: Gets latest created release info
         id: latest_release_info
@@ -256,6 +273,7 @@ jobs:
           artifacts_release_process: ${{ steps.upload_release_process.outputs.browser_download_url }} 
           artifacts_documentation: ${{ steps.upload_doc.outputs.browser_download_url }}
           artifacts_requirements: ${{ steps.upload_doc.outputs.browser_download_url }}
+          artifacts_binaries: ${{ steps.upload_nodeagent_amd64.outputs.browser_download_url }}
           artifacts_testing: >
             ${{ steps.upload_test_report.outputs.browser_download_url }},
             ${{ steps.upload_license_report.outputs.browser_download_url }},

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -44,34 +44,61 @@ jobs:
           mkdir -p dist/coverage/player
           mkdir -p dist/coverage/tools
           mkdir -p dist/coverage/agent
+          mkdir -p dist/binaries
 
       # Step 7: Run project build and parse logs
       - name: Build and parse project
         run: ./scripts/buildNparse.sh
 
-      # Step 8: Run all Rust unit/integration tests and generate reports
+      # Step 8: Build nodeagent binary for release (x86_64 only)
+      - name: Build nodeagent binary (x86_64)
+        run: |
+          echo "Building nodeagent from src/agent/nodeagent directory..."
+          
+          # Build from the nodeagent package directory
+          cd src/agent/nodeagent
+          cargo build --release
+          
+          # Go back to project root
+          cd ../../../
+          
+          # The binary should be at src/agent/target/release/nodeagent (based on your output)
+          if [ -f "src/agent/target/release/nodeagent" ]; then
+            echo "Found binary at: src/agent/target/release/nodeagent"
+            cp src/agent/target/release/nodeagent dist/binaries/nodeagent-linux-amd64
+          else
+            echo "Binary not found, searching entire project..."
+            find . -name "nodeagent" -type f -executable
+            exit 1
+          fi
+          
+          # Verify binary was created
+          ls -la dist/binaries/
+          file dist/binaries/nodeagent-linux-amd64
+
+      # Step 9: Run all Rust unit/integration tests and generate reports
       - name: Run tests and generate report
         run: ./scripts/testNparse.sh
 
-      # Step 9: Linting (clippy)
+      # Step 10: Linting (clippy)
       - name: Run Clippy (lint)
         run: ./scripts/clippy_check.sh
 
-      # Step 10: Formatting check
+      # Step 11: Formatting check
       - name: Run format check
         run: ./scripts/fmt_check.sh
 
-      # Step 11: License, ban, and security checks with cargo-deny
+      # Step 12: License, ban, and security checks with cargo-deny
       - name: Run cargo-deny checks
         run: ./scripts/deny_check.sh
 
-      # Step 12: Run test coverage script
+      # Step 13: Run test coverage script
       - name: Run test coverage script
         run: ./scripts/test_coverage.sh
 
       # === Upload All Reports ===
 
-      # Step 13: Upload deny report
+      # Step 14: Upload deny report
       - name: Upload deny report
         if: always()
         uses: actions/upload-artifact@v4
@@ -79,7 +106,7 @@ jobs:
           name: deny-report
           path: dist/reports/deny/deny_summary.md
 
-      # Step 14: Upload format report
+      # Step 15: Upload format report
       - name: Upload fmt report
         if: always()
         uses: actions/upload-artifact@v4
@@ -87,7 +114,7 @@ jobs:
           name: fmt-report
           path: dist/reports/fmt/fmt_summary.md
 
-      # Step 15: Upload all test reports (JUnit-style)
+      # Step 16: Upload all test reports (JUnit-style)
       - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@v4
@@ -95,7 +122,15 @@ jobs:
           name: test-report
           path: dist/tests/*
 
-      # Step 16: Upload test coverage reports
+      # Step 17: Upload nodeagent binary
+      - name: Upload nodeagent binary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nodeagent-binary
+          path: dist/binaries/nodeagent-linux-amd64
+
+      # Step 18: Upload test coverage reports
       - name: Upload Overall coverage reports
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
📝 PR Description
release nodeagent binary on release page[#228]


🔗 Related Issue
Closes-> https://github.com/eclipse-pullpiri/pullpiri/issues/228

🧪 Test Method
Below is the sample link tested on personal repo:
Nodeagent binary will be generated and upload to the assets when a release will done through git push -v
https://github.com/akshayg0314/cicd_pullpiri/releases/tag/v1.0.114
✅ Checklist
[✅] Code conventions are followed
[✅] Tests are added/modified
[✅] Documentation is updated (if necessary)