### PR TITLE
feat(api)-Store BoardInfo, SocInfo, NodeInfo to ETCD[#223]

### DIFF
--- a/src/common/build.rs
+++ b/src/common/build.rs
@@ -4,12 +4,19 @@
  */
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("proto/actioncontroller.proto")?;
-    tonic_build::compile_protos("proto/filtergateway.proto")?;
-    tonic_build::compile_protos("proto/monitoringserver.proto")?;
-    tonic_build::compile_protos("proto/nodeagent.proto")?;
-    tonic_build::compile_protos("proto/policymanager.proto")?;
-    tonic_build::compile_protos("proto/statemanager.proto")?;
-    tonic_build::compile_protos("proto/pharos_service.proto")?;
+    tonic_build::configure()
+        .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
+        .compile_protos(
+            &[
+                "proto/actioncontroller.proto",
+                "proto/filtergateway.proto",
+                "proto/monitoringserver.proto",
+                "proto/nodeagent.proto",
+                "proto/policymanager.proto",
+                "proto/statemanager.proto",
+                "proto/pharos_service.proto",
+            ],
+            &["proto"],
+        )?;
     Ok(())
 }

--- a/src/server/Cargo.lock
+++ b/src/server/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
  "config",
  "const_format",
  "etcd-client",
- "prost",
+ "prost 0.13.5",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -649,7 +649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0452bcc559431b16f472b7ab86e2f9ccd5f3c2da3795afbd6b773665e047fe"
 dependencies = [
  "http",
- "prost",
+ "prost 0.13.5",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -1412,6 +1412,9 @@ name = "monitoringserver"
 version = "0.1.0"
 dependencies = [
  "common",
+ "prost 0.14.1",
+ "serde",
+ "serde_json",
  "tokio",
  "tonic",
 ]
@@ -1851,7 +1854,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.1",
 ]
 
 [[package]]
@@ -1867,7 +1880,7 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
+ "prost 0.13.5",
  "prost-types",
  "regex",
  "syn",
@@ -1888,12 +1901,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
- "prost",
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -2240,9 +2266,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",
@@ -2697,7 +2723,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "socket2",
  "tokio",
  "tokio-stream",

--- a/src/server/monitoringserver/src/etcd_storage.rs
+++ b/src/server/monitoringserver/src/etcd_storage.rs
@@ -7,138 +7,112 @@
 
 use crate::data_structures::{BoardInfo, SocInfo};
 use common::monitoringserver::NodeInfo;
+use serde::{Serialize, de::DeserializeOwned};
+
+/// Generic function to store info in etcd
+async fn store_info<T: Serialize>(resource_type: &str, resource_id: &str, info: &T) -> common::Result<()> {
+    let key = format!("/piccolo/metrics/{}/{}", resource_type, resource_id);
+    let json_data = serde_json::to_string(info)
+        .map_err(|e| format!("Failed to serialize {}: {}", resource_type, e))?;
+
+    common::etcd::put(&key, &json_data).await?;
+    println!("[ETCD] Stored {} for {}: {}", resource_type, resource_type, resource_id);
+    Ok(())
+}
+
+/// Generic function to retrieve info from etcd
+async fn get_info<T: DeserializeOwned>(resource_type: &str, resource_id: &str) -> common::Result<T> {
+    let key = format!("/piccolo/metrics/{}/{}", resource_type, resource_id);
+    let json_data = common::etcd::get(&key).await?;
+
+    let info: T = serde_json::from_str(&json_data)
+        .map_err(|e| format!("Failed to deserialize {}: {}", resource_type, e))?;
+
+    Ok(info)
+}
+
+/// Generic function to delete info from etcd
+async fn delete_info(resource_type: &str, resource_id: &str) -> common::Result<()> {
+    let key = format!("/piccolo/metrics/{}/{}", resource_type, resource_id);
+    common::etcd::delete(&key).await?;
+    println!("[ETCD] Deleted {} for {}: {}", resource_type, resource_type, resource_id);
+    Ok(())
+}
+
+/// Generic function to get all items of a type from etcd
+async fn get_all_info<T: DeserializeOwned>(resource_type: &str) -> common::Result<Vec<T>> {
+    let prefix = format!("/piccolo/metrics/{}/", resource_type);
+    let kv_pairs = common::etcd::get_all_with_prefix(&prefix).await?;
+
+    let mut items = Vec::new();
+    for kv in kv_pairs {
+        match serde_json::from_str::<T>(&kv.value) {
+            Ok(item) => items.push(item),
+            Err(e) => eprintln!("[ETCD] Failed to deserialize {} {}: {}", resource_type, kv.key, e),
+        }
+    }
+
+    Ok(items)
+}
+
+// Public API functions using the generic implementations
 
 /// Store NodeInfo in etcd
 pub async fn store_node_info(node_info: &NodeInfo) -> common::Result<()> {
-    let key = format!("/piccolo/metrics/nodes/{}", node_info.node_name);
-    let json_data = serde_json::to_string(node_info)
-        .map_err(|e| format!("Failed to serialize NodeInfo: {}", e))?;
-
-    common::etcd::put(&key, &json_data).await?;
-    println!("[ETCD] Stored NodeInfo for node: {}", node_info.node_name);
-    Ok(())
+    store_info("nodes", &node_info.node_name, node_info).await
 }
 
 /// Store SocInfo in etcd
 pub async fn store_soc_info(soc_info: &SocInfo) -> common::Result<()> {
-    let key = format!("/piccolo/metrics/socs/{}", soc_info.soc_id);
-    let json_data = serde_json::to_string(soc_info)
-        .map_err(|e| format!("Failed to serialize SocInfo: {}", e))?;
-
-    common::etcd::put(&key, &json_data).await?;
-    println!("[ETCD] Stored SocInfo for SoC: {}", soc_info.soc_id);
-    Ok(())
+    store_info("socs", &soc_info.soc_id, soc_info).await
 }
 
 /// Store BoardInfo in etcd
 pub async fn store_board_info(board_info: &BoardInfo) -> common::Result<()> {
-    let key = format!("/piccolo/metrics/boards/{}", board_info.board_id);
-    let json_data = serde_json::to_string(board_info)
-        .map_err(|e| format!("Failed to serialize BoardInfo: {}", e))?;
-
-    common::etcd::put(&key, &json_data).await?;
-    println!("[ETCD] Stored BoardInfo for board: {}", board_info.board_id);
-    Ok(())
+    store_info("boards", &board_info.board_id, board_info).await
 }
 
 /// Retrieve NodeInfo from etcd
 pub async fn get_node_info(node_name: &str) -> common::Result<NodeInfo> {
-    let key = format!("/piccolo/metrics/nodes/{}", node_name);
-    let json_data = common::etcd::get(&key).await?;
-
-    let node_info: NodeInfo = serde_json::from_str(&json_data)
-        .map_err(|e| format!("Failed to deserialize NodeInfo: {}", e))?;
-
-    Ok(node_info)
+    get_info("nodes", node_name).await
 }
 
 /// Retrieve SocInfo from etcd
 pub async fn get_soc_info(soc_id: &str) -> common::Result<SocInfo> {
-    let key = format!("/piccolo/metrics/socs/{}", soc_id);
-    let json_data = common::etcd::get(&key).await?;
-
-    let soc_info: SocInfo = serde_json::from_str(&json_data)
-        .map_err(|e| format!("Failed to deserialize SocInfo: {}", e))?;
-
-    Ok(soc_info)
+    get_info("socs", soc_id).await
 }
 
 /// Retrieve BoardInfo from etcd
 pub async fn get_board_info(board_id: &str) -> common::Result<BoardInfo> {
-    let key = format!("/piccolo/metrics/boards/{}", board_id);
-    let json_data = common::etcd::get(&key).await?;
-
-    let board_info: BoardInfo = serde_json::from_str(&json_data)
-        .map_err(|e| format!("Failed to deserialize BoardInfo: {}", e))?;
-
-    Ok(board_info)
+    get_info("boards", board_id).await
 }
 
 /// Get all nodes from etcd
 pub async fn get_all_nodes() -> common::Result<Vec<NodeInfo>> {
-    let kv_pairs = common::etcd::get_all_with_prefix("/piccolo/metrics/nodes/").await?;
-
-    let mut nodes = Vec::with_capacity(kv_pairs.len());
-    for kv in kv_pairs {
-        match serde_json::from_str::<NodeInfo>(&kv.value) {
-            Ok(node_info) => nodes.push(node_info),
-            Err(e) => eprintln!("[ETCD] Failed to deserialize node {}: {}", kv.key, e),
-        }
-    }
-
-    Ok(nodes)
+    get_all_info("nodes").await
 }
 
 /// Get all SoCs from etcd
 pub async fn get_all_socs() -> common::Result<Vec<SocInfo>> {
-    let kv_pairs = common::etcd::get_all_with_prefix("/piccolo/metrics/socs/").await?;
-
-    let mut socs = Vec::new();
-    for kv in kv_pairs {
-        match serde_json::from_str::<SocInfo>(&kv.value) {
-            Ok(soc_info) => socs.push(soc_info),
-            Err(e) => eprintln!("[ETCD] Failed to deserialize SoC {}: {}", kv.key, e),
-        }
-    }
-
-    Ok(socs)
+    get_all_info("socs").await
 }
 
 /// Get all boards from etcd
 pub async fn get_all_boards() -> common::Result<Vec<BoardInfo>> {
-    let kv_pairs = common::etcd::get_all_with_prefix("/piccolo/metrics/boards/").await?;
-
-    let mut boards = Vec::new();
-    for kv in kv_pairs {
-        match serde_json::from_str::<BoardInfo>(&kv.value) {
-            Ok(board_info) => boards.push(board_info),
-            Err(e) => eprintln!("[ETCD] Failed to deserialize board {}: {}", kv.key, e),
-        }
-    }
-
-    Ok(boards)
+    get_all_info("boards").await
 }
 
 /// Delete NodeInfo from etcd
 pub async fn delete_node_info(node_name: &str) -> common::Result<()> {
-    let key = format!("/piccolo/metrics/nodes/{}", node_name);
-    common::etcd::delete(&key).await?;
-    println!("[ETCD] Deleted NodeInfo for node: {}", node_name);
-    Ok(())
+    delete_info("nodes", node_name).await
 }
 
 /// Delete SocInfo from etcd
 pub async fn delete_soc_info(soc_id: &str) -> common::Result<()> {
-    let key = format!("/piccolo/metrics/socs/{}", soc_id);
-    common::etcd::delete(&key).await?;
-    println!("[ETCD] Deleted SocInfo for SoC: {}", soc_id);
-    Ok(())
+    delete_info("socs", soc_id).await
 }
 
 /// Delete BoardInfo from etcd
 pub async fn delete_board_info(board_id: &str) -> common::Result<()> {
-    let key = format!("/piccolo/metrics/boards/{}", board_id);
-    common::etcd::delete(&key).await?;
-    println!("[ETCD] Deleted BoardInfo for board: {}", board_id);
-    Ok(())
+    delete_info("boards", board_id).await
 }

--- a/src/server/monitoringserver/src/etcd_storage.rs
+++ b/src/server/monitoringserver/src/etcd_storage.rs
@@ -21,8 +21,8 @@ async fn store_info<T: Serialize>(
 
     common::etcd::put(&key, &json_data).await?;
     println!(
-        "[ETCD] Stored {} for {}: {}",
-        resource_type, resource_type, resource_id
+        "[ETCD] Stored the metrics for {}: {}",
+        resource_type, resource_id
     );
     Ok(())
 }
@@ -46,8 +46,8 @@ async fn delete_info(resource_type: &str, resource_id: &str) -> common::Result<(
     let key = format!("/piccolo/metrics/{}/{}", resource_type, resource_id);
     common::etcd::delete(&key).await?;
     println!(
-        "[ETCD] Deleted {} for {}: {}",
-        resource_type, resource_type, resource_id
+        "[ETCD] Deleted the metrics for {}: {}",
+        resource_type, resource_id
     );
     Ok(())
 }

--- a/src/server/monitoringserver/src/etcd_storage.rs
+++ b/src/server/monitoringserver/src/etcd_storage.rs
@@ -10,7 +10,7 @@ use common::monitoringserver::NodeInfo;
 
 /// Store NodeInfo in etcd
 pub async fn store_node_info(node_info: &NodeInfo) -> common::Result<()> {
-    let key = format!("monitoring/nodes/{}", node_info.node_name);
+    let key = format!("/piccolo/metrics/nodes/{}", node_info.node_name);
     let json_data = serde_json::to_string(node_info)
         .map_err(|e| format!("Failed to serialize NodeInfo: {}", e))?;
 
@@ -21,7 +21,7 @@ pub async fn store_node_info(node_info: &NodeInfo) -> common::Result<()> {
 
 /// Store SocInfo in etcd
 pub async fn store_soc_info(soc_info: &SocInfo) -> common::Result<()> {
-    let key = format!("monitoring/socs/{}", soc_info.soc_id);
+    let key = format!("/piccolo/metrics/socs/{}", soc_info.soc_id);
     let json_data = serde_json::to_string(soc_info)
         .map_err(|e| format!("Failed to serialize SocInfo: {}", e))?;
 
@@ -32,7 +32,7 @@ pub async fn store_soc_info(soc_info: &SocInfo) -> common::Result<()> {
 
 /// Store BoardInfo in etcd
 pub async fn store_board_info(board_info: &BoardInfo) -> common::Result<()> {
-    let key = format!("monitoring/boards/{}", board_info.board_id);
+    let key = format!("/piccolo/metrics/boards/{}", board_info.board_id);
     let json_data = serde_json::to_string(board_info)
         .map_err(|e| format!("Failed to serialize BoardInfo: {}", e))?;
 
@@ -43,7 +43,7 @@ pub async fn store_board_info(board_info: &BoardInfo) -> common::Result<()> {
 
 /// Retrieve NodeInfo from etcd
 pub async fn get_node_info(node_name: &str) -> common::Result<NodeInfo> {
-    let key = format!("monitoring/nodes/{}", node_name);
+    let key = format!("/piccolo/metrics/nodes/{}", node_name);
     let json_data = common::etcd::get(&key).await?;
 
     let node_info: NodeInfo = serde_json::from_str(&json_data)
@@ -54,7 +54,7 @@ pub async fn get_node_info(node_name: &str) -> common::Result<NodeInfo> {
 
 /// Retrieve SocInfo from etcd
 pub async fn get_soc_info(soc_id: &str) -> common::Result<SocInfo> {
-    let key = format!("monitoring/socs/{}", soc_id);
+    let key = format!("/piccolo/metrics/socs/{}", soc_id);
     let json_data = common::etcd::get(&key).await?;
 
     let soc_info: SocInfo = serde_json::from_str(&json_data)
@@ -65,7 +65,7 @@ pub async fn get_soc_info(soc_id: &str) -> common::Result<SocInfo> {
 
 /// Retrieve BoardInfo from etcd
 pub async fn get_board_info(board_id: &str) -> common::Result<BoardInfo> {
-    let key = format!("monitoring/boards/{}", board_id);
+    let key = format!("/piccolo/metrics/boards/{}", board_id);
     let json_data = common::etcd::get(&key).await?;
 
     let board_info: BoardInfo = serde_json::from_str(&json_data)
@@ -76,7 +76,7 @@ pub async fn get_board_info(board_id: &str) -> common::Result<BoardInfo> {
 
 /// Get all nodes from etcd
 pub async fn get_all_nodes() -> common::Result<Vec<NodeInfo>> {
-    let kv_pairs = common::etcd::get_all_with_prefix("monitoring/nodes/").await?;
+    let kv_pairs = common::etcd::get_all_with_prefix("/piccolo/metrics/nodes/").await?;
 
     let mut nodes = Vec::with_capacity(kv_pairs.len());
     for kv in kv_pairs {
@@ -91,7 +91,7 @@ pub async fn get_all_nodes() -> common::Result<Vec<NodeInfo>> {
 
 /// Get all SoCs from etcd
 pub async fn get_all_socs() -> common::Result<Vec<SocInfo>> {
-    let kv_pairs = common::etcd::get_all_with_prefix("monitoring/socs/").await?;
+    let kv_pairs = common::etcd::get_all_with_prefix("/piccolo/metrics/socs/").await?;
 
     let mut socs = Vec::new();
     for kv in kv_pairs {
@@ -106,7 +106,7 @@ pub async fn get_all_socs() -> common::Result<Vec<SocInfo>> {
 
 /// Get all boards from etcd
 pub async fn get_all_boards() -> common::Result<Vec<BoardInfo>> {
-    let kv_pairs = common::etcd::get_all_with_prefix("monitoring/boards/").await?;
+    let kv_pairs = common::etcd::get_all_with_prefix("/piccolo/metrics/boards/").await?;
 
     let mut boards = Vec::new();
     for kv in kv_pairs {
@@ -121,7 +121,7 @@ pub async fn get_all_boards() -> common::Result<Vec<BoardInfo>> {
 
 /// Delete NodeInfo from etcd
 pub async fn delete_node_info(node_name: &str) -> common::Result<()> {
-    let key = format!("monitoring/nodes/{}", node_name);
+    let key = format!("/piccolo/metrics/nodes/{}", node_name);
     common::etcd::delete(&key).await?;
     println!("[ETCD] Deleted NodeInfo for node: {}", node_name);
     Ok(())
@@ -129,7 +129,7 @@ pub async fn delete_node_info(node_name: &str) -> common::Result<()> {
 
 /// Delete SocInfo from etcd
 pub async fn delete_soc_info(soc_id: &str) -> common::Result<()> {
-    let key = format!("monitoring/socs/{}", soc_id);
+    let key = format!("/piccolo/metrics/socs/{}", soc_id);
     common::etcd::delete(&key).await?;
     println!("[ETCD] Deleted SocInfo for SoC: {}", soc_id);
     Ok(())
@@ -137,7 +137,7 @@ pub async fn delete_soc_info(soc_id: &str) -> common::Result<()> {
 
 /// Delete BoardInfo from etcd
 pub async fn delete_board_info(board_id: &str) -> common::Result<()> {
-    let key = format!("monitoring/boards/{}", board_id);
+    let key = format!("/piccolo/metrics/boards/{}", board_id);
     common::etcd::delete(&key).await?;
     println!("[ETCD] Deleted BoardInfo for board: {}", board_id);
     Ok(())

--- a/src/server/monitoringserver/src/etcd_storage.rs
+++ b/src/server/monitoringserver/src/etcd_storage.rs
@@ -1,0 +1,144 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2024 LG Electronics Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Store and retrieve monitoring data in etcd
+
+use crate::data_structures::{BoardInfo, SocInfo};
+use common::monitoringserver::NodeInfo;
+
+/// Store NodeInfo in etcd
+pub async fn store_node_info(node_info: &NodeInfo) -> common::Result<()> {
+    let key = format!("monitoring/nodes/{}", node_info.node_name);
+    let json_data = serde_json::to_string(node_info)
+        .map_err(|e| format!("Failed to serialize NodeInfo: {}", e))?;
+
+    common::etcd::put(&key, &json_data).await?;
+    println!("[ETCD] Stored NodeInfo for node: {}", node_info.node_name);
+    Ok(())
+}
+
+/// Store SocInfo in etcd
+pub async fn store_soc_info(soc_info: &SocInfo) -> common::Result<()> {
+    let key = format!("monitoring/socs/{}", soc_info.soc_id);
+    let json_data = serde_json::to_string(soc_info)
+        .map_err(|e| format!("Failed to serialize SocInfo: {}", e))?;
+
+    common::etcd::put(&key, &json_data).await?;
+    println!("[ETCD] Stored SocInfo for SoC: {}", soc_info.soc_id);
+    Ok(())
+}
+
+/// Store BoardInfo in etcd
+pub async fn store_board_info(board_info: &BoardInfo) -> common::Result<()> {
+    let key = format!("monitoring/boards/{}", board_info.board_id);
+    let json_data = serde_json::to_string(board_info)
+        .map_err(|e| format!("Failed to serialize BoardInfo: {}", e))?;
+
+    common::etcd::put(&key, &json_data).await?;
+    println!("[ETCD] Stored BoardInfo for board: {}", board_info.board_id);
+    Ok(())
+}
+
+/// Retrieve NodeInfo from etcd
+pub async fn get_node_info(node_name: &str) -> common::Result<NodeInfo> {
+    let key = format!("monitoring/nodes/{}", node_name);
+    let json_data = common::etcd::get(&key).await?;
+
+    let node_info: NodeInfo = serde_json::from_str(&json_data)
+        .map_err(|e| format!("Failed to deserialize NodeInfo: {}", e))?;
+
+    Ok(node_info)
+}
+
+/// Retrieve SocInfo from etcd
+pub async fn get_soc_info(soc_id: &str) -> common::Result<SocInfo> {
+    let key = format!("monitoring/socs/{}", soc_id);
+    let json_data = common::etcd::get(&key).await?;
+
+    let soc_info: SocInfo = serde_json::from_str(&json_data)
+        .map_err(|e| format!("Failed to deserialize SocInfo: {}", e))?;
+
+    Ok(soc_info)
+}
+
+/// Retrieve BoardInfo from etcd
+pub async fn get_board_info(board_id: &str) -> common::Result<BoardInfo> {
+    let key = format!("monitoring/boards/{}", board_id);
+    let json_data = common::etcd::get(&key).await?;
+
+    let board_info: BoardInfo = serde_json::from_str(&json_data)
+        .map_err(|e| format!("Failed to deserialize BoardInfo: {}", e))?;
+
+    Ok(board_info)
+}
+
+/// Get all nodes from etcd
+pub async fn get_all_nodes() -> common::Result<Vec<NodeInfo>> {
+    let kv_pairs = common::etcd::get_all_with_prefix("monitoring/nodes/").await?;
+
+    let mut nodes = Vec::with_capacity(kv_pairs.len());
+    for kv in kv_pairs {
+        match serde_json::from_str::<NodeInfo>(&kv.value) {
+            Ok(node_info) => nodes.push(node_info),
+            Err(e) => eprintln!("[ETCD] Failed to deserialize node {}: {}", kv.key, e),
+        }
+    }
+
+    Ok(nodes)
+}
+
+/// Get all SoCs from etcd
+pub async fn get_all_socs() -> common::Result<Vec<SocInfo>> {
+    let kv_pairs = common::etcd::get_all_with_prefix("monitoring/socs/").await?;
+
+    let mut socs = Vec::new();
+    for kv in kv_pairs {
+        match serde_json::from_str::<SocInfo>(&kv.value) {
+            Ok(soc_info) => socs.push(soc_info),
+            Err(e) => eprintln!("[ETCD] Failed to deserialize SoC {}: {}", kv.key, e),
+        }
+    }
+
+    Ok(socs)
+}
+
+/// Get all boards from etcd
+pub async fn get_all_boards() -> common::Result<Vec<BoardInfo>> {
+    let kv_pairs = common::etcd::get_all_with_prefix("monitoring/boards/").await?;
+
+    let mut boards = Vec::new();
+    for kv in kv_pairs {
+        match serde_json::from_str::<BoardInfo>(&kv.value) {
+            Ok(board_info) => boards.push(board_info),
+            Err(e) => eprintln!("[ETCD] Failed to deserialize board {}: {}", kv.key, e),
+        }
+    }
+
+    Ok(boards)
+}
+
+/// Delete NodeInfo from etcd
+pub async fn delete_node_info(node_name: &str) -> common::Result<()> {
+    let key = format!("monitoring/nodes/{}", node_name);
+    common::etcd::delete(&key).await?;
+    println!("[ETCD] Deleted NodeInfo for node: {}", node_name);
+    Ok(())
+}
+
+/// Delete SocInfo from etcd
+pub async fn delete_soc_info(soc_id: &str) -> common::Result<()> {
+    let key = format!("monitoring/socs/{}", soc_id);
+    common::etcd::delete(&key).await?;
+    println!("[ETCD] Deleted SocInfo for SoC: {}", soc_id);
+    Ok(())
+}
+
+/// Delete BoardInfo from etcd
+pub async fn delete_board_info(board_id: &str) -> common::Result<()> {
+    let key = format!("monitoring/boards/{}", board_id);
+    common::etcd::delete(&key).await?;
+    println!("[ETCD] Deleted BoardInfo for board: {}", board_id);
+    Ok(())
+}

--- a/src/server/monitoringserver/src/etcd_storage.rs
+++ b/src/server/monitoringserver/src/etcd_storage.rs
@@ -7,21 +7,31 @@
 
 use crate::data_structures::{BoardInfo, SocInfo};
 use common::monitoringserver::NodeInfo;
-use serde::{Serialize, de::DeserializeOwned};
+use serde::{de::DeserializeOwned, Serialize};
 
 /// Generic function to store info in etcd
-async fn store_info<T: Serialize>(resource_type: &str, resource_id: &str, info: &T) -> common::Result<()> {
+async fn store_info<T: Serialize>(
+    resource_type: &str,
+    resource_id: &str,
+    info: &T,
+) -> common::Result<()> {
     let key = format!("/piccolo/metrics/{}/{}", resource_type, resource_id);
     let json_data = serde_json::to_string(info)
         .map_err(|e| format!("Failed to serialize {}: {}", resource_type, e))?;
 
     common::etcd::put(&key, &json_data).await?;
-    println!("[ETCD] Stored {} for {}: {}", resource_type, resource_type, resource_id);
+    println!(
+        "[ETCD] Stored {} for {}: {}",
+        resource_type, resource_type, resource_id
+    );
     Ok(())
 }
 
 /// Generic function to retrieve info from etcd
-async fn get_info<T: DeserializeOwned>(resource_type: &str, resource_id: &str) -> common::Result<T> {
+async fn get_info<T: DeserializeOwned>(
+    resource_type: &str,
+    resource_id: &str,
+) -> common::Result<T> {
     let key = format!("/piccolo/metrics/{}/{}", resource_type, resource_id);
     let json_data = common::etcd::get(&key).await?;
 
@@ -35,7 +45,10 @@ async fn get_info<T: DeserializeOwned>(resource_type: &str, resource_id: &str) -
 async fn delete_info(resource_type: &str, resource_id: &str) -> common::Result<()> {
     let key = format!("/piccolo/metrics/{}/{}", resource_type, resource_id);
     common::etcd::delete(&key).await?;
-    println!("[ETCD] Deleted {} for {}: {}", resource_type, resource_type, resource_id);
+    println!(
+        "[ETCD] Deleted {} for {}: {}",
+        resource_type, resource_type, resource_id
+    );
     Ok(())
 }
 
@@ -48,7 +61,10 @@ async fn get_all_info<T: DeserializeOwned>(resource_type: &str) -> common::Resul
     for kv in kv_pairs {
         match serde_json::from_str::<T>(&kv.value) {
             Ok(item) => items.push(item),
-            Err(e) => eprintln!("[ETCD] Failed to deserialize {} {}: {}", resource_type, kv.key, e),
+            Err(e) => eprintln!(
+                "[ETCD] Failed to deserialize {} {}: {}",
+                resource_type, kv.key, e
+            ),
         }
     }
 

--- a/src/server/monitoringserver/src/main.rs
+++ b/src/server/monitoringserver/src/main.rs
@@ -5,6 +5,7 @@
 
 use common::monitoringserver::{ContainerList, NodeInfo};
 pub mod data_structures;
+pub mod etcd_storage;
 pub mod grpc;
 pub mod manager;
 

--- a/src/server/monitoringserver/src/manager.rs
+++ b/src/server/monitoringserver/src/manager.rs
@@ -24,10 +24,6 @@ pub struct MonitoringServerManager {
 
 impl MonitoringServerManager {
     /// Creates a new MonitoringServerManager instance.
-    ///
-    /// # Arguments
-    /// * `rx_container` - Channel receiver for container information
-    /// * `rx_node` - Channel receiver for node information
     pub async fn new(
         rx_container: mpsc::Receiver<ContainerList>,
         rx_node: mpsc::Receiver<NodeInfo>,
@@ -74,13 +70,14 @@ impl MonitoringServerManager {
         // Print detailed NodeInfo first
         self.print_node_info(&node_info);
 
-        // Store NodeInfo and update SocInfo/BoardInfo
+        // Store NodeInfo and update SocInfo/BoardInfo with etcd storage
         {
             let mut data_store = self.data_store.lock().await;
-            match data_store.store_node_info(node_info.clone()) {
+            match data_store.store_node_info(node_info.clone()).await {
+                // Add .await here
                 Ok(_) => {
                     println!(
-                        "[MonitoringServer]  Successfully stored NodeInfo for {}",
+                        "[MonitoringServer] SUCCESS: Successfully stored NodeInfo for {}",
                         node_info.node_name
                     );
 
@@ -97,12 +94,12 @@ impl MonitoringServerManager {
                     self.print_summary_stats(&data_store).await;
                 }
                 Err(e) => {
-                    eprintln!("[MonitoringServer] ❌ Error storing NodeInfo: {}", e);
+                    eprintln!("[MonitoringServer] ERROR: Error storing NodeInfo: {}", e);
                 }
             }
         }
 
-        println!("{}", "=".repeat(80)); // Separator line
+        println!("{}", "=".repeat(80));
     }
 
     /// Print ID generation details for debugging


### PR DESCRIPTION
📝 PR Description
feat(api)-Store BoardInfo, SocInfo, NodeInfo to ETCD
->validating full build error.
->testing statemanger, monitoringserver, nodeagent

🔗 Related Issue
Closes-> https://github.com/eclipse-pullpiri/pullpiri/issues/223

🧪 Test Method
Run statemanager and monitoringserver first, and run nodeagent second.
Look at the monitoringserver's log and check if monitoringserver receives the NodeInfo message.
Check ETCD storage after running.

Sample logs:


```
acrn@acrn-NUC11TNHi5:~/new_ak/new/pullpiri/src/server/monitoringserver$ etcdctl get "" --prefix
monitoring/boards/192.168.2.0
{"board_id":"192.168.2.0","nodes":[{"node_name":"acrn-NUC11TNHi5","cpu_usage":6.092287540435791,"cpu_count":8,"gpu_count":1,"used_memory":5600530432,"total_memory":33294245888,"mem_usage":16.82131576538086,"rx_bytes":6161,"tx_bytes":7903,"read_bytes":0,"write_bytes":40960,"os":"Linux (Ubuntu 22.04)","arch":"x86_64","ip":"192.168.2.30"}],"socs":[{"soc_id":"192.168.2.30","nodes":[{"node_name":"acrn-NUC11TNHi5","cpu_usage":6.092287540435791,"cpu_count":8,"gpu_count":1,"used_memory":5600530432,"total_memory":33294245888,"mem_usage":16.82131576538086,"rx_bytes":6161,"tx_bytes":7903,"read_bytes":0,"write_bytes":40960,"os":"Linux (Ubuntu 22.04)","arch":"x86_64","ip":"192.168.2.30"}],"total_cpu_usage":6.092287540435791,"total_cpu_count":8,"total_gpu_count":1,"total_used_memory":5600530432,"total_memory":33294245888,"total_mem_usage":16.82131636451498,"total_rx_bytes":6161,"total_tx_bytes":7903,"total_read_bytes":0,"total_write_bytes":40960,"last_updated":{"secs_since_epoch":1757323513,"nanos_since_epoch":714024821}}],"total_cpu_usage":6.092287540435791,"total_cpu_count":8,"total_gpu_count":1,"total_used_memory":5600530432,"total_memory":33294245888,"total_mem_usage":16.82131636451498,"total_rx_bytes":6161,"total_tx_bytes":7903,"total_read_bytes":0,"total_write_bytes":40960,"last_updated":{"secs_since_epoch":1757323513,"nanos_since_epoch":714030301}}
monitoring/nodes/acrn-NUC11TNHi5
{"node_name":"acrn-NUC11TNHi5","cpu_usage":6.092287540435791,"cpu_count":8,"gpu_count":1,"used_memory":5600530432,"total_memory":33294245888,"mem_usage":16.82131576538086,"rx_bytes":6161,"tx_bytes":7903,"read_bytes":0,"write_bytes":40960,"os":"Linux (Ubuntu 22.04)","arch":"x86_64","ip":"192.168.2.30"}
monitoring/socs/192.168.2.30
{"soc_id":"192.168.2.30","nodes":[{"node_name":"acrn-NUC11TNHi5","cpu_usage":6.092287540435791,"cpu_count":8,"gpu_count":1,"used_memory":5600530432,"total_memory":33294245888,"mem_usage":16.82131576538086,"rx_bytes":6161,"tx_bytes":7903,"read_bytes":0,"write_bytes":40960,"os":"Linux (Ubuntu 22.04)","arch":"x86_64","ip":"192.168.2.30"}],"total_cpu_usage":6.092287540435791,"total_cpu_count":8,"total_gpu_count":1,"total_used_memory":5600530432,"total_memory":33294245888,"total_mem_usage":16.82131636451498,"total_rx_bytes":6161,"total_tx_bytes":7903,"total_read_bytes":0,"total_write_bytes":40960,"last_updated":{"secs_since_epoch":1757323513,"nanos_since_epoch":714024821}}

```
✅ Checklist
[✅] Code conventions are followed
[✅] Tests are added/modified
[✅] Documentation is updated (if necessary)