### PR TITLE
feat(Nodeagent): build without nodeagent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@
 .PHONY: default build
 build:
 	cargo build --manifest-path=src/common/Cargo.toml
-	cargo build --manifest-path=src/agent/Cargo.toml
 	cargo build --manifest-path=src/player/Cargo.toml
 	cargo build --manifest-path=src/server/Cargo.toml
 	cargo build --manifest-path=src/tools/Cargo.toml
@@ -12,7 +11,6 @@ build:
 .PHONY: release
 release:
 	cargo build --manifest-path=src/common/Cargo.toml --release
-	cargo build --manifest-path=src/agent/Cargo.toml --release
 	cargo build --manifest-path=src/player/Cargo.toml --release
 	cargo build --manifest-path=src/server/Cargo.toml --release
 	cargo build --manifest-path=src/tools/Cargo.toml --release
@@ -20,7 +18,6 @@ release:
 .PHONY: clean
 clean:
 	cargo clean --manifest-path=src/common/Cargo.toml
-	cargo clean --manifest-path=src/agent/Cargo.toml
 	cargo clean --manifest-path=src/player/Cargo.toml
 	cargo clean --manifest-path=src/server/Cargo.toml
 	cargo clean --manifest-path=src/tools/Cargo.toml
@@ -68,12 +65,10 @@ install:
 	-cp -r ./containers/piccolo-*.* /etc/containers/systemd/piccolo/
 	systemctl daemon-reload
 	systemctl start piccolo-server
-	systemctl start piccolo-agent
 	systemctl start piccolo-player
 
 .PHONY: uninstall
 uninstall:
-	-systemctl stop piccolo-agent
 	-systemctl stop piccolo-player
 	-systemctl stop piccolo-server
 	systemctl daemon-reload


### PR DESCRIPTION
📝 PR Description
build without nodeagent
feat(nodeagent) : build without
This pull request updates the `Makefile` to remove all references to the `agent` component from the build, release, clean, install, and uninstall processes. This streamlines the workflow by no longer building, cleaning, or managing the `piccolo-agent` service.

Build and release process changes:
* Removed `cargo build`, `cargo build --release`, and `cargo clean` commands for `src/agent/Cargo.toml`, so the agent component is no longer included in these steps.

Service management updates:
* Removed `systemctl start piccolo-agent` from the install process, so the agent service is no longer started during installation.
* Removed `systemctl stop piccolo-agent` from the uninstall process, so the agent service is no longer stopped during uninstallation. nodeagent

🔗 Related Issue


🧪 Test Method


✅ Checklist
[✅] 