### PR TITLE
fix(sender): update StateManagerConnectionClient connection to use master IP from config (url : #330)

### DIFF
--- a/src/agent/nodeagent/src/grpc/sender.rs
+++ b/src/agent/nodeagent/src/grpc/sender.rs
@@ -92,8 +92,11 @@ impl NodeAgentSender {
         &mut self,
         container_list: ContainerList,
     ) -> Result<tonic::Response<SendContainerListResponse>, Status> {
-        let client =
-            StateManagerConnectionClient::connect(common::statemanager::connect_server()).await;
+        let config = crate::config::Config::get();
+        let master_ip = config.nodeagent.master_ip.clone();
+        let addr = format!("http://{}:47006", master_ip);
+
+        let client = StateManagerConnectionClient::connect(addr).await;
 
         match client {
             Ok(mut client) => {


### PR DESCRIPTION
related to #330 

There're "Failed to connect" errors when sending changed container list from NodeAgent to StateManager. Because NodeAgent lies on each Node, NodeAgent needs some other approach to connect to StateManager.