### PR TITLE
feat(monitoringserver)-Stress monitoring metrics from App Data Provider

### DIFF
--- a/src/common/proto/monitoringserver.proto
+++ b/src/common/proto/monitoringserver.proto
@@ -10,6 +10,7 @@ package monitoringserver;
 service MonitoringServerConnection {
   rpc SendContainerList (ContainerList) returns (SendContainerListResponse);
   rpc SendNodeInfo (NodeInfo) returns (SendNodeInfoResponse);
+  rpc SendStressMonitoringMetric (StressMonitoringMetric) returns (StressMonitoringMetricResponse);
 }
 
 message SendContainerListResponse {
@@ -50,4 +51,13 @@ message NodeInfo {
   string os = 12;
   string arch = 13;
   string ip = 14;
+}
+
+// Stress monitoring metric: single JSON string payload from App Data Provider
+message StressMonitoringMetric {
+  string json = 1; // JSON string containing process_name, pid, core_masking, core_count, fps, latency, cpu_loads, etc.
+}
+
+message StressMonitoringMetricResponse {
+  string resp = 1;
 }

--- a/src/server/monitoringserver/src/data_structures.rs
+++ b/src/server/monitoringserver/src/data_structures.rs
@@ -812,7 +812,7 @@ mod tests {
         let node = sample_node("node1", "192.168.10.201");
         let soc = SocInfo::new("192.168.10.200".to_string(), node.clone());
         ds.socs.insert("192.168.10.200".to_string(), soc.clone());
-        let mut board = BoardInfo::new("192.168.10.200".to_string(), node.clone());
+        let board = BoardInfo::new("192.168.10.200".to_string(), node.clone());
         ds.boards
             .insert("192.168.10.200".to_string(), board.clone());
 

--- a/src/server/monitoringserver/src/grpc/receiver.rs
+++ b/src/server/monitoringserver/src/grpc/receiver.rs
@@ -1,15 +1,75 @@
 use common::monitoringserver::monitoring_server_connection_server::MonitoringServerConnection;
 use common::monitoringserver::{
     ContainerList, NodeInfo, SendContainerListResponse, SendNodeInfoResponse,
+    StressMonitoringMetric, StressMonitoringMetricResponse,
 };
 use tokio::sync::mpsc;
 use tonic::{Request, Response, Status};
+
+use serde::Deserialize;
+use serde_json;
+use std::fmt;
+
+/// JSON types for StressMonitoringMetric payload
+#[derive(Debug, Deserialize)]
+pub struct CpuLoad {
+    pub core_id: u32,
+    pub load: f64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StressMonitoringMetricParsed {
+    pub process_name: String,
+    pub pid: u32,
+    pub core_masking: Option<String>,
+    pub core_count: Option<u32>,
+    pub fps: f64,
+    pub latency: u64,
+    pub cpu_loads: Vec<CpuLoad>,
+}
+
+impl StressMonitoringMetricParsed {
+    // If core_count was provided, return it; otherwise derive from max core_id in cpu_loads.
+    pub fn effective_core_count(&self) -> u32 {
+        if let Some(c) = self.core_count {
+            c
+        } else {
+            self.cpu_loads
+                .iter()
+                .map(|c| c.core_id)
+                .max()
+                .unwrap_or(0)
+                .saturating_add(1)
+        }
+    }
+}
+
+impl fmt::Display for StressMonitoringMetricParsed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "process={} pid={} cores={} fps={} latency={}",
+            self.process_name,
+            self.pid,
+            self.effective_core_count(),
+            self.fps,
+            self.latency
+        )
+    }
+}
+
+pub fn parse_stress_metric_json(
+    s: &str,
+) -> Result<StressMonitoringMetricParsed, serde_json::Error> {
+    serde_json::from_str(s)
+}
 
 /// MonitoringServer gRPC service handler
 #[derive(Clone)]
 pub struct MonitoringServerReceiver {
     pub tx_container: mpsc::Sender<ContainerList>,
     pub tx_node: mpsc::Sender<NodeInfo>,
+    pub tx_stress: mpsc::Sender<String>,
 }
 
 #[tonic::async_trait]
@@ -53,17 +113,38 @@ impl MonitoringServerConnection for MonitoringServerReceiver {
             )),
         }
     }
+
+    /// Handle a StressMonitoringMetric message (single JSON string) from App Data Provider
+    ///
+    /// Parses the JSON payload to validate format, then forwards the original JSON string to the manager via channel.
+    async fn send_stress_monitoring_metric<'life>(
+        &'life self,
+        request: Request<StressMonitoringMetric>,
+    ) -> Result<Response<StressMonitoringMetricResponse>, Status> {
+        let req: StressMonitoringMetric = request.into_inner();
+        // validate JSON by parsing to struct
+        parse_stress_metric_json(&req.json)
+            .map_err(|e| Status::invalid_argument(format!("invalid stress metric json: {}", e)))?;
+
+        match self.tx_stress.send(req.json).await {
+            Ok(_) => Ok(Response::new(StressMonitoringMetricResponse {
+                resp: "Successfully processed StressMonitoringMetric".to_string(),
+            })),
+            Err(e) => Err(Status::new(
+                tonic::Code::Unavailable,
+                format!("cannot send stress metric: {}", e),
+            )),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use common::monitoringserver::{
-        ContainerList, NodeInfo, SendContainerListResponse, SendNodeInfoResponse,
-    };
+    use common::monitoringserver::{ContainerList, NodeInfo, StressMonitoringMetric};
     use tokio::sync::mpsc;
     use tokio::time::{timeout, Duration};
-    use tonic::{Code, Request, Status};
+    use tonic::{Code, Request};
 
     fn sample_node(name: &str, ip: &str) -> NodeInfo {
         NodeInfo {
@@ -91,13 +172,32 @@ mod tests {
         }
     }
 
+    fn sample_stress_json() -> String {
+        r#"{
+            "process_name":"example_process",
+            "pid":12345,
+            "core_masking":"0x0000F",
+            "core_count":20,
+            "fps":58.7,
+            "latency":38,
+            "cpu_loads":[
+                {"core_id":0,"load":23.5},
+                {"core_id":1,"load":45.2},
+                {"core_id":2,"load":12.8}
+            ]
+        }"#
+        .to_string()
+    }
+
     #[tokio::test]
     async fn test_send_container_list_success() {
         let (tx, mut rx) = mpsc::channel(1);
-        let dummy_tx = mpsc::channel(1).0;
+        let dummy_tx_node = mpsc::channel::<NodeInfo>(1).0;
+        let dummy_stress = mpsc::channel::<String>(1).0;
         let receiver = MonitoringServerReceiver {
             tx_container: tx,
-            tx_node: dummy_tx,
+            tx_node: dummy_tx_node,
+            tx_stress: dummy_stress,
         };
         let req = Request::new(sample_container_list("node1"));
         let resp = receiver.send_container_list(req).await.unwrap();
@@ -113,9 +213,11 @@ mod tests {
         let (tx, rx) = mpsc::channel(1);
         drop(rx);
         let dummy_tx = mpsc::channel(1).0;
+        let dummy_stress = mpsc::channel(1).0;
         let receiver = MonitoringServerReceiver {
             tx_container: tx,
             tx_node: dummy_tx,
+            tx_stress: dummy_stress,
         };
         let req = Request::new(sample_container_list("node1"));
         let resp = receiver.send_container_list(req).await;
@@ -127,10 +229,12 @@ mod tests {
     #[tokio::test]
     async fn test_send_node_info_success() {
         let (tx, mut rx) = mpsc::channel(1);
-        let dummy_tx = mpsc::channel(1).0;
+        let dummy_tx_container = mpsc::channel::<ContainerList>(1).0;
+        let dummy_stress = mpsc::channel::<String>(1).0;
         let receiver = MonitoringServerReceiver {
-            tx_container: dummy_tx,
+            tx_container: dummy_tx_container,
             tx_node: tx,
+            tx_stress: dummy_stress,
         };
         let req = Request::new(sample_node("node1", "192.168.10.201"));
         let resp = receiver.send_node_info(req).await.unwrap();
@@ -146,14 +250,103 @@ mod tests {
         let (tx, rx) = mpsc::channel(1);
         drop(rx);
         let dummy_tx = mpsc::channel(1).0;
+        let dummy_stress = mpsc::channel(1).0;
         let receiver = MonitoringServerReceiver {
             tx_container: dummy_tx,
             tx_node: tx,
+            tx_stress: dummy_stress,
         };
         let req = Request::new(sample_node("node1", "192.168.10.201"));
         let resp = receiver.send_node_info(req).await;
         assert!(resp.is_err());
         let status = resp.err().unwrap();
         assert_eq!(status.code(), Code::Unavailable);
+    }
+
+    #[tokio::test]
+    async fn test_send_stress_metric_success() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let dummy_tx_container = mpsc::channel::<ContainerList>(1).0;
+        let dummy_tx_node = mpsc::channel::<NodeInfo>(1).0;
+        let receiver = MonitoringServerReceiver {
+            tx_container: dummy_tx_container,
+            tx_node: dummy_tx_node,
+            tx_stress: tx,
+        };
+        let req = Request::new(StressMonitoringMetric {
+            json: sample_stress_json(),
+        });
+        let resp = receiver.send_stress_monitoring_metric(req).await.unwrap();
+        assert_eq!(
+            resp.get_ref().resp,
+            "Successfully processed StressMonitoringMetric"
+        );
+        let received = timeout(Duration::from_millis(100), rx.recv()).await;
+        assert!(received.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_send_stress_metric_roundtrip() {
+        use crate::etcd_storage;
+        use crate::manager;
+
+        // create channels: tx -> receiver, rx -> manager
+        let (tx_container, rx_container) = mpsc::channel::<ContainerList>(4);
+        let (tx_node, rx_node) = mpsc::channel::<NodeInfo>(4);
+        let (tx_stress, rx_stress) = mpsc::channel::<String>(8);
+
+        // create and spawn the real manager (it will consume rx_stress and call etcd)
+        let mgr = manager::MonitoringServerManager::new(rx_container, rx_node, rx_stress).await;
+        let mgr_handle = tokio::spawn(async move {
+            // run will spawn internal tasks and block until channels are closed
+            let _ = mgr.run().await;
+        });
+
+        // construct receiver with the tx side of the channels
+        let receiver = MonitoringServerReceiver {
+            tx_container: tx_container.clone(),
+            tx_node: tx_node.clone(),
+            tx_stress: tx_stress.clone(),
+        };
+
+        // send the stress metric via gRPC handler (synchronous call)
+        let req = Request::new(StressMonitoringMetric {
+            json: sample_stress_json(),
+        });
+        let resp = receiver.send_stress_monitoring_metric(req).await.unwrap();
+        assert_eq!(
+            resp.get_ref().resp,
+            "Successfully processed StressMonitoringMetric"
+        );
+
+        // wait briefly for manager to process and store to etcd
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        // verify etcd has at least one stress metric with expected process_name
+        // NOTE: requires working etcd and correct common::etcd configuration
+        let metrics = etcd_storage::get_all_stress_metrics().await;
+        assert!(
+            metrics.is_ok(),
+            "failed to list stress metrics from etcd: {:?}",
+            metrics.err()
+        );
+        let items = metrics.unwrap();
+        let found = items.iter().any(|v| {
+            v.get("process_name")
+                .and_then(|s| s.as_str())
+                .map(|s| s == "example_process")
+                .unwrap_or(false)
+        });
+        assert!(
+            found,
+            "stored stress metric with process_name 'example_process' not found in etcd"
+        );
+
+        // cleanup: drop tx to allow manager tasks to exit, then await manager handle
+        drop(tx_container);
+        drop(tx_node);
+        drop(tx_stress);
+
+        // give manager a moment to finish
+        let _ = tokio::time::timeout(Duration::from_secs(1), mgr_handle).await;
     }
 }

--- a/src/server/monitoringserver/src/main.rs
+++ b/src/server/monitoringserver/src/main.rs
@@ -16,8 +16,12 @@ use tokio::sync::mpsc::{channel, Receiver, Sender};
 ///
 /// This function creates the manager, initializes it, and then runs it.
 /// If initialization or running fails, errors are printed to stderr.
-async fn launch_manager(rx_container: Receiver<ContainerList>, rx_node: Receiver<NodeInfo>) {
-    let mut manager = manager::MonitoringServerManager::new(rx_container, rx_node).await;
+async fn launch_manager(
+    rx_container: Receiver<ContainerList>,
+    rx_node: Receiver<NodeInfo>,
+    rx_stress: Receiver<String>,
+) {
+    let mut manager = manager::MonitoringServerManager::new(rx_container, rx_node, rx_stress).await;
 
     match manager.initialize().await {
         Ok(_) => {
@@ -35,12 +39,17 @@ async fn launch_manager(rx_container: Receiver<ContainerList>, rx_node: Receiver
 /// Initializes the MonitoringServer gRPC server.
 ///
 /// Sets up the gRPC service and starts listening for incoming requests.
-async fn initialize(tx_container: Sender<ContainerList>, tx_node: Sender<NodeInfo>) {
+async fn initialize(
+    tx_container: Sender<ContainerList>,
+    tx_node: Sender<NodeInfo>,
+    tx_stress: Sender<String>,
+) {
     use tonic::transport::Server;
 
     let server = grpc::receiver::MonitoringServerReceiver {
         tx_container,
         tx_node,
+        tx_stress,
     };
 
     let addr = common::monitoringserver::open_server()
@@ -64,8 +73,11 @@ async fn main() {
     let (tx_container, rx_container) = channel::<ContainerList>(100);
     let (tx_node, rx_node) = channel::<NodeInfo>(100);
 
-    let mgr = launch_manager(rx_container, rx_node);
-    let grpc = initialize(tx_container, tx_node);
+    // Add stress channel and a simple consumer
+    let (tx_stress, rx_stress) = channel::<String>(16);
+
+    let mgr = launch_manager(rx_container, rx_node, rx_stress);
+    let grpc = initialize(tx_container, tx_node, tx_stress);
 
     tokio::join!(mgr, grpc);
 }
@@ -73,71 +85,31 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use common::monitoringserver::{ContainerInfo, ContainerList, NodeInfo};
-    use std::collections::HashMap;
     use tokio::time::{timeout, Duration};
-
-    fn sample_node(name: &str, ip: &str) -> NodeInfo {
-        NodeInfo {
-            node_name: name.to_string(),
-            ip: ip.to_string(),
-            cpu_usage: 42.0,
-            cpu_count: 2,
-            gpu_count: 1,
-            used_memory: 1024,
-            total_memory: 2048,
-            mem_usage: 50.0,
-            rx_bytes: 100,
-            tx_bytes: 200,
-            read_bytes: 300,
-            write_bytes: 400,
-            arch: "x86_64".to_string(),
-            os: "linux".to_string(),
-        }
-    }
-
-    fn sample_container(id: &str, name: &str, status: &str) -> ContainerInfo {
-        let mut state = HashMap::new();
-        state.insert("Status".to_string(), status.to_string());
-        ContainerInfo {
-            id: id.to_string(),
-            names: vec![name.to_string()],
-            image: "testimg".to_string(),
-            state,
-            ..Default::default()
-        }
-    }
-
-    fn sample_container_list(node_name: &str, containers: Vec<ContainerInfo>) -> ContainerList {
-        ContainerList {
-            node_name: node_name.to_string(),
-            containers,
-        }
-    }
 
     #[tokio::test]
     async fn test_launch_manager_completes() {
-        let (tx_c, rx_c) = tokio::sync::mpsc::channel(1);
-        let (tx_n, rx_n) = tokio::sync::mpsc::channel(1);
-
+        let (_tx_c, rx_c) = tokio::sync::mpsc::channel(1);
+        let (_tx_n, rx_n) = tokio::sync::mpsc::channel(1);
+        let (_tx_s, rx_s) = tokio::sync::mpsc::channel::<String>(1);
         // Use a timeout to ensure the test does not hang
-        let result = timeout(Duration::from_secs(2), launch_manager(rx_c, rx_n)).await;
+        let _result = timeout(Duration::from_secs(2), launch_manager(rx_c, rx_n, rx_s)).await;
         //assert!(result.is_ok(), "launch_manager did not complete in time");
     }
 
     #[tokio::test]
     async fn test_initialize_completes() {
-        let (tx_c, mut rx_c) = tokio::sync::mpsc::channel(1);
-        let (tx_n, mut rx_n) = tokio::sync::mpsc::channel(1);
-
+        let (tx_c, _rx_c) = tokio::sync::mpsc::channel(1);
+        let (tx_n, _rx_n) = tokio::sync::mpsc::channel(1);
+        let (tx_s, _rx_s) = tokio::sync::mpsc::channel::<String>(1);
         // Spawn initialize in a background task and cancel after a short delay
         let handle = tokio::spawn(async move {
             // Use a short timeout to avoid hanging on .serve()
-            let _ = timeout(Duration::from_millis(500), initialize(tx_c, tx_n)).await;
+            let _ = timeout(Duration::from_millis(500), initialize(tx_c, tx_n, tx_s)).await;
         });
 
         // Wait for the task to finish or timeout
-        let result = timeout(Duration::from_secs(1), handle).await;
-        assert!(result.is_ok(), "initialize did not complete in time");
+        let _result = timeout(Duration::from_secs(1), handle).await;
+        assert!(_result.is_ok(), "initialize did not complete in time");
     }
 }


### PR DESCRIPTION
📝 **PR Description**
Stress monitoring metrics from App Data Provider[#361]
Parse the StressMonitoringMetric message on MonitoringServer [#362]
Store the StressMonitoringMetric to ETCD on MonitoringServer [#363]

🔗 **Related Issue**
Closes: [#361][#362][#363]


🧪 Test Method
sudo cargo test test_send_stress_metric_roundtrip -- --nocapture

**Screenshots:**
<img width="1922" height="444" alt="image" src="https://github.com/user-attachments/assets/e2c0e986-6232-44d6-9092-f246b62b3ca2" />

✅ Checklist
[✅] Code conventions are followed
[✅] Tests are added/modified
[✅] Documentation is updated (if necessary)
