### PR TITLE
initialiing domain ID setting on fail with settings.yaml

### DIFF
--- a/src/player/filtergateway/src/vehicle/mod.rs
+++ b/src/player/filtergateway/src/vehicle/mod.rs
@@ -43,10 +43,9 @@ impl VehicleManager {
             Err(e) => {
                 log::warn!("Failed to initialize DDS manager with settings file: {}. Using default settings.", e);
                 // 기본 설정 적용
+                self.set_domain_id(100); // Set default domain ID
             }
         }
-        self.set_domain_id(100); // Set default domain ID
-
         Ok(())
     }
 


### PR DESCRIPTION
move initialized domain id of DDS into failing code.