### PR TITLE
feat: Add Resource Manager proto definitions for Network and Volume m…

### DIFF
--- a/src/common/build.rs
+++ b/src/common/build.rs
@@ -26,6 +26,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "proto/external/pharos/pharos_service.proto",
                 "proto/external/timpani/schedinfo.proto",
                 "proto/rocksdbservice.proto", // Add RocksDB service proto
+                "proto/resourcemanager.proto", // Add Resource Manager proto
+                "proto/external/csi/csi_service.proto", // Add CSI service proto
             ],
             &["proto"],
         )?;

--- a/src/common/proto/external/csi/csi_service.proto
+++ b/src/common/proto/external/csi/csi_service.proto
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2024 LG Electronics Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+syntax = "proto3";
+package csi.api.v1;
+
+// CSI Volume Manager service for Resource Manager
+service CsiVolumeManager {
+  rpc CreateVolume(VolumeCreateRequest) returns (VolumeCreateResponse);
+  rpc DeleteVolume(VolumeDeleteRequest) returns (VolumeDeleteResponse);
+}
+
+message VolumeCreateRequest {
+  string volume_name = 1;
+  string capacity = 2;          // e.g., "10Gi", "1Ti"
+  string mountpath = 3;         // e.g., "/mnt/data"
+  string asil_level = 4;        // e.g., "ASIL-A", "ASIL-B", "ASIL-D", "QM"
+}
+
+message VolumeCreateResponse {
+  bool success = 1;
+  string message = 2;
+}
+
+message VolumeDeleteRequest {
+  string volume_name = 1;
+}
+
+message VolumeDeleteResponse {
+  bool success = 1;
+  string message = 2;
+}

--- a/src/common/proto/external/pharos/pharos_service.proto
+++ b/src/common/proto/external/pharos/pharos_service.proto
@@ -20,3 +20,28 @@ message RequestNetworkPodResponse {
   bool accepted = 2;
   string message = 3;
 }
+
+// Network Manager service for Resource Manager
+service PharosNetworkManager {
+  rpc SetupNetwork(NetworkSetupRequest) returns (NetworkSetupResponse);
+  rpc RemoveNetwork(NetworkRemoveRequest) returns (NetworkRemoveResponse);
+}
+
+message NetworkSetupRequest {
+  string network_name = 1;
+  string network_mode = 2;  // bridge, host, overlay, macvlan, etc.
+}
+
+message NetworkSetupResponse {
+  bool success = 1;
+  string message = 2;
+}
+
+message NetworkRemoveRequest {
+  string network_name = 1;
+}
+
+message NetworkRemoveResponse {
+  bool success = 1;
+  string message = 2;
+}

--- a/src/common/proto/resourcemanager.proto
+++ b/src/common/proto/resourcemanager.proto
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2024 LG Electronics Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+syntax = "proto3";
+package resourcemanager;
+
+// Resource Manager service - receives requests from API Server
+service ResourceManagerService {
+  rpc CreateNetworkResource(NetworkResourceRequest) returns (ResourceResponse);
+  rpc CreateVolumeResource(VolumeResourceRequest) returns (ResourceResponse);
+  rpc DeleteNetworkResource(DeleteResourceRequest) returns (ResourceResponse);
+  rpc DeleteVolumeResource(DeleteResourceRequest) returns (ResourceResponse);
+}
+
+// Network Resource Request (from API Server)
+message NetworkResourceRequest {
+  string network_name = 1;
+  string network_mode = 2;      // bridge, host, overlay, macvlan, etc.
+  string node_name = 3;         // Target node name (optional)
+}
+
+// Volume Resource Request (from API Server)
+message VolumeResourceRequest {
+  string volume_name = 1;
+  string capacity = 2;          // e.g., "10Gi", "1Ti"
+  string mountpath = 3;         // e.g., "/mnt/data"
+  string asil_level = 4;        // e.g., "ASIL-A", "ASIL-B", "ASIL-D", "QM"
+  string node_name = 5;         // Target node name (optional)
+}
+
+// Delete Resource Request
+message DeleteResourceRequest {
+  string resource_name = 1;
+}
+
+// Generic Resource Response
+message ResourceResponse {
+  bool success = 1;
+  string message = 2;
+}


### PR DESCRIPTION
…anagement

- Add resourcemanager.proto: API Server to Resource Manager interface
  * CreateNetworkResource/CreateVolumeResource RPCs
  * DeleteNetworkResource/DeleteVolumeResource RPCs
  * Network: network_name, network_mode, node_name
  * Volume: volume_name, capacity, mountpath, asil_level, node_name

- Add external/csi/csi_service.proto: Resource Manager to CSI interface
  * CreateVolume/DeleteVolume RPCs
  * Volume parameters: capacity, mountpath, asil_level

- Update external/pharos/pharos_service.proto: Resource Manager to Pharos interface
  * Add PharosNetworkManager service
  * SetupNetwork/RemoveNetwork RPCs
  * Network parameters: network_name, network_mode

- Update build.rs: Add new proto files to compilation

This implements the gRPC flow: API Server → Resource Manager → external components (Pharos Network Manager, CSI)