### PR TITLE
refactor(settingscli): improve output formatting to kubectl-style

### DIFF
--- a/src/tools/settingscli/src/commands/board.rs
+++ b/src/tools/settingscli/src/commands/board.rs
@@ -5,7 +5,7 @@
 //! Board command implementation
 
 use crate::commands::format::{format_bytes, format_duration_ago, format_memory};
-use crate::commands::{print_error, print_info, print_json, print_success};
+use crate::commands::{print_error, print_info, print_json, print_success, print_table_header};
 use crate::{Result, SettingsClient};
 use clap::Subcommand;
 use colored::Colorize;
@@ -47,39 +47,54 @@ async fn get_boards(client: &SettingsClient) -> Result<()> {
 
     match client.get("/api/v1/boards").await {
         Ok(boards) => {
-            println!("\n{}", "Boards".bold());
-            println!("{}", "=".repeat(50));
+            print_table_header("Boards", &[
+                ("ID", 24),
+                ("NODES", 10),
+                ("SOCS", 10),
+            ]);
 
             // Look for "boards" array in the response
             if let Some(boards_array) = boards.get("boards").and_then(|b| b.as_array()) {
                 if boards_array.is_empty() {
                     println!("No boards found.");
                 } else {
-                    for (i, board) in boards_array.iter().enumerate() {
-                        println!("{}. Board:", i + 1);
-                        if let Some(id) = board.get("board_id") {
-                            println!("   ID: {}", id.as_str().unwrap_or("Unknown"));
-                        }
-                        // Name and status may not exist in your schema, so print if present
-                        if let Some(name) = board.get("name") {
-                            println!("   Name: {}", name.as_str().unwrap_or("Unknown"));
-                        }
-                        if let Some(status) = board.get("status") {
-                            println!("   Status: {}", status.as_str().unwrap_or("Unknown"));
-                        }
-                        println!();
+                    // Print each board
+                    for board in boards_array.iter() {
+                        let id = board.get("board_id").and_then(|i| i.as_str()).unwrap_or("Unknown");
+                        let node_count = board.get("nodes")
+                            .and_then(|n| n.as_array())
+                            .map(|arr| arr.len())
+                            .unwrap_or(0);
+                        let soc_count = board.get("socs")
+                            .and_then(|s| s.as_array())
+                            .map(|arr| arr.len())
+                            .unwrap_or(0);
+
+                        println!(
+                            "{:<24} {:<10} {:<10}",
+                            id, node_count, soc_count
+                        );
                     }
                 }
             } else if let Some(id) = boards.get("board_id") {
                 // Single board response
-                println!("Board ID: {}", id.as_str().unwrap_or("Unknown"));
-                if let Some(name) = boards.get("name") {
-                    println!("Name: {}", name.as_str().unwrap_or("Unknown"));
-                }
+                let node_count = boards.get("nodes")
+                    .and_then(|n| n.as_array())
+                    .map(|arr| arr.len())
+                    .unwrap_or(0);
+                let soc_count = boards.get("socs")
+                    .and_then(|s| s.as_array())
+                    .map(|arr| arr.len())
+                    .unwrap_or(0);
+                println!(
+                    "{:<24} {:<10} {:<10}",
+                    id.as_str().unwrap_or("Unknown"), node_count, soc_count
+                );
             } else {
                 println!("No boards found.");
             }
 
+            println!();
             print_success("Boards list retrieved successfully");
         }
         Err(e) => {

--- a/src/tools/settingscli/src/commands/container.rs
+++ b/src/tools/settingscli/src/commands/container.rs
@@ -3,10 +3,10 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 use crate::commands::format::{
-    calculate_runtime, calculate_uptime, capitalize, extract_network_value, format_bytes,
-    format_timestamp,
+    calculate_age, calculate_runtime, calculate_uptime, capitalize, extract_network_value,
+    format_bytes, format_timestamp,
 };
-use crate::commands::{print_error, print_info, print_success};
+use crate::commands::{print_error, print_info, print_success, print_table_header};
 use crate::{Result, SettingsClient};
 use clap::Subcommand;
 use colored::Colorize;
@@ -35,77 +35,67 @@ async fn get_containers(client: &SettingsClient) -> Result<()> {
 
     match client.get("/api/v1/containers").await {
         Ok(containers) => {
-            println!("\n{}", "Containers".bold());
-            println!("{}", "=".repeat(50));
-
             // If the response is an array, iterate and print each container
-            if let Some(containers_array) = containers.as_array() {
-                if containers_array.is_empty() {
-                    println!("No containers found.");
-                } else {
-                    for (i, container) in containers_array.iter().enumerate() {
-                        println!("{}. Container:", i + 1);
-                        if let Some(id) = container.get("id") {
-                            println!("   ID: {}", id.as_str().unwrap_or("Unknown"));
-                        }
-                        if let Some(names) = container.get("names").and_then(|n| n.as_array()) {
-                            if let Some(first_name) = names.first().and_then(|n| n.as_str()) {
-                                println!("   Name: {}", first_name);
-                            }
-                        }
-                        if let Some(image) = container.get("image") {
-                            println!("   Image: {}", image.as_str().unwrap_or("Unknown"));
-                        }
-                        if let Some(state) = container.get("state") {
-                            if let Some(status) = state.get("Status") {
-                                println!("   Status: {}", status.as_str().unwrap_or("Unknown"));
-                            }
-                        }
-                        if let Some(config) = container.get("config") {
-                            if let Some(hostname) = config.get("Hostname") {
-                                println!("   Hostname: {}", hostname.as_str().unwrap_or("Unknown"));
-                            }
-                        }
-                        println!();
-                    }
-                }
-            } else if let Some(containers_obj) =
-                containers.get("containers").and_then(|c| c.as_array())
-            {
-                // Handle wrapped response format
-                if containers_obj.is_empty() {
-                    println!("No containers found.");
-                } else {
-                    for (i, container) in containers_obj.iter().enumerate() {
-                        println!("{}. Container:", i + 1);
-                        if let Some(id) = container.get("id") {
-                            println!("   ID: {}", id.as_str().unwrap_or("Unknown"));
-                        }
-                        if let Some(names) = container.get("names").and_then(|n| n.as_array()) {
-                            if let Some(first_name) = names.first().and_then(|n| n.as_str()) {
-                                println!("   Name: {}", first_name);
-                            }
-                        }
-                        if let Some(image) = container.get("image") {
-                            println!("   Image: {}", image.as_str().unwrap_or("Unknown"));
-                        }
-                        if let Some(state) = container.get("state") {
-                            if let Some(status) = state.get("Status") {
-                                println!("   Status: {}", status.as_str().unwrap_or("Unknown"));
-                            }
-                        }
-                        if let Some(config) = container.get("config") {
-                            if let Some(hostname) = config.get("Hostname") {
-                                println!("   Hostname: {}", hostname.as_str().unwrap_or("Unknown"));
-                            }
-                        }
-                        println!();
-                    }
-                }
+            let containers_array = if let Some(array) = containers.as_array() {
+                array
+            } else if let Some(array) = containers.get("containers").and_then(|c| c.as_array()) {
+                array
             } else {
                 println!("No containers found.");
+                print_success("Containers list retrieved successfully");
+                return Ok(());
+            };
+
+            if containers_array.is_empty() {
+                println!("No containers found.");
+            } else {
+                print_table_header("Containers", &[
+                    ("NAME", 32),
+                    ("STATUS", 12),
+                    ("ID", 14),
+                    ("AGE", 8),
+                ]);
+
+                // Print each container
+                for container in containers_array.iter() {
+                    let name = container
+                        .get("names")
+                        .and_then(|n| n.as_array())
+                        .and_then(|arr| arr.first())
+                        .and_then(|n| n.as_str())
+                        .unwrap_or("Unknown");
+
+                    let status = container
+                        .get("state")
+                        .and_then(|s| s.get("Status"))
+                        .and_then(|st| st.as_str())
+                        .unwrap_or("Unknown");
+
+                    let id = container
+                        .get("id")
+                        .and_then(|i| i.as_str())
+                        .unwrap_or("Unknown");
+                    let short_id = if id.len() >= 12 {
+                        &id[0..12]
+                    } else {
+                        id
+                    };
+
+                    let age = container
+                        .get("state")
+                        .and_then(|s| s.get("StartedAt"))
+                        .and_then(|t| t.as_str())
+                        .and_then(|t| calculate_age(t).ok())
+                        .unwrap_or_else(|| "N/A".to_string());
+
+                    println!(
+                        "{:<32} {:<12} {:<14} {:<8}",
+                        name, status, short_id, age
+                    );
+                }
             }
 
+            println!();
             print_success("Containers list retrieved successfully");
         }
         Err(e) => {

--- a/src/tools/settingscli/src/commands/format.rs
+++ b/src/tools/settingscli/src/commands/format.rs
@@ -100,6 +100,36 @@ pub fn calculate_uptime(started_at: &str) -> std::result::Result<String, Box<dyn
     }
 }
 
+/// Calculate age from start timestamp in kubectl style
+/// Returns format like "6d", "5h", "30m", "45s"
+pub fn calculate_age(started_at: &str) -> std::result::Result<String, Box<dyn std::error::Error>> {
+    use chrono::{DateTime, Utc};
+    
+    // Check for invalid timestamps
+    if started_at.starts_with("0001-") {
+        return Ok("N/A".to_string());
+    }
+    
+    let started = DateTime::parse_from_rfc3339(started_at)?;
+    let now = Utc::now();
+    let duration = now.signed_duration_since(started);
+    
+    let days = duration.num_days();
+    let hours = duration.num_hours();
+    let minutes = duration.num_minutes();
+    let seconds = duration.num_seconds();
+    
+    if days > 0 {
+        Ok(format!("{}d", days))
+    } else if hours > 0 {
+        Ok(format!("{}h", hours))
+    } else if minutes > 0 {
+        Ok(format!("{}m", minutes))
+    } else {
+        Ok(format!("{}s", seconds))
+    }
+}
+
 /// Calculate runtime between two timestamps
 /// Returns format like "1.234s" or "0.005s"
 pub fn calculate_runtime(started_at: &str, finished_at: &str) -> std::result::Result<String, Box<dyn std::error::Error>> {

--- a/src/tools/settingscli/src/commands/mod.rs
+++ b/src/tools/settingscli/src/commands/mod.rs
@@ -38,3 +38,17 @@ pub fn print_error(message: &str) {
 pub fn print_info(message: &str) {
     println!("{} {}", "ℹ".blue().bold(), message);
 }
+
+/// Print table header with title and columns
+/// 
+/// # Arguments
+/// * `title` - Table title (e.g., "Boards", "Nodes")
+/// * `columns` - Array of (column_name, width) tuples
+pub fn print_table_header(_title: &str, columns: &[(&str, usize)]) {
+    // Print column headers only (kubectl style - simple and clean)
+    println!();
+    for (name, width) in columns {
+        print!("{:<width$} ", name, width = width);
+    }
+    println!();
+}

--- a/src/tools/settingscli/src/commands/node.rs
+++ b/src/tools/settingscli/src/commands/node.rs
@@ -5,7 +5,7 @@
 //! Node command implementation
 
 use crate::commands::format::{format_bytes, format_memory};
-use crate::commands::{print_error, print_info, print_json, print_success};
+use crate::commands::{print_error, print_info, print_json, print_success, print_table_header};
 use crate::{Result, SettingsClient};
 use clap::Subcommand;
 use colored::Colorize;
@@ -47,50 +47,45 @@ async fn get_nodes(client: &SettingsClient) -> Result<()> {
 
     match client.get("/api/v1/nodes").await {
         Ok(nodes) => {
-            println!("\n{}", "Nodes".bold());
-            println!("{}", "=".repeat(50));
+            print_table_header("Nodes", &[
+                ("NAME", 24),
+                ("IP", 18),
+                ("OS", 22),
+                ("ARCH", 10),
+            ]);
 
             // Look for "nodes" array in the response
             if let Some(nodes_array) = nodes.get("nodes").and_then(|n| n.as_array()) {
                 if nodes_array.is_empty() {
                     println!("No nodes found.");
                 } else {
-                    for (i, node) in nodes_array.iter().enumerate() {
-                        println!("{}. Node:", i + 1);
-                        if let Some(name) = node.get("node_name") {
-                            println!("   Name: {}", name.as_str().unwrap_or("Unknown"));
-                        }
-                        if let Some(ip) = node.get("ip") {
-                            println!("   IP: {}", ip.as_str().unwrap_or("Unknown"));
-                        }
-                        if let Some(arch) = node.get("arch") {
-                            println!("   Architecture: {}", arch.as_str().unwrap_or("Unknown"));
-                        }
-                        if let Some(os) = node.get("os") {
-                            println!("   OS: {}", os.as_str().unwrap_or("Unknown"));
-                        }
-                        if let Some(cpu_count) = node.get("cpu_count") {
-                            println!("   CPU Count: {}", cpu_count.as_u64().unwrap_or(0));
-                        }
-                        if let Some(cpu_usage) = node.get("cpu_usage") {
-                            println!("   CPU Usage: {:.2}%", cpu_usage.as_f64().unwrap_or(0.0));
-                        }
-                        if let Some(mem_usage) = node.get("mem_usage") {
-                            println!("   Memory Usage: {:.2}%", mem_usage.as_f64().unwrap_or(0.0));
-                        }
-                        println!();
+                    // Print each node
+                    for node in nodes_array.iter() {
+                        let name = node.get("node_name").and_then(|n| n.as_str()).unwrap_or("Unknown");
+                        let ip = node.get("ip").and_then(|i| i.as_str()).unwrap_or("N/A");
+                        let os = node.get("os").and_then(|o| o.as_str()).unwrap_or("Unknown");
+                        let arch = node.get("arch").and_then(|a| a.as_str()).unwrap_or("Unknown");
+
+                        println!(
+                            "{:<24} {:<18} {:<22} {:<10}",
+                            name, ip, os, arch
+                        );
                     }
                 }
             } else if let Some(name) = nodes.get("node_name") {
                 // Single node response
-                println!("Node Name: {}", name.as_str().unwrap_or("Unknown"));
-                if let Some(ip) = nodes.get("ip") {
-                    println!("IP: {}", ip.as_str().unwrap_or("Unknown"));
-                }
+                let ip = nodes.get("ip").and_then(|i| i.as_str()).unwrap_or("N/A");
+                let os = nodes.get("os").and_then(|o| o.as_str()).unwrap_or("Unknown");
+                let arch = nodes.get("arch").and_then(|a| a.as_str()).unwrap_or("Unknown");
+                println!(
+                    "{:<24} {:<18} {:<22} {:<10}",
+                    name.as_str().unwrap_or("Unknown"), ip, os, arch
+                );
             } else {
                 println!("No nodes found.");
             }
 
+            println!();
             print_success("Nodes list retrieved successfully");
         }
         Err(e) => {

--- a/src/tools/settingscli/src/commands/soc.rs
+++ b/src/tools/settingscli/src/commands/soc.rs
@@ -5,7 +5,7 @@
 //! SoC command implementation
 
 use crate::commands::format::{format_bytes, format_duration_ago, format_memory};
-use crate::commands::{print_error, print_info, print_json, print_success};
+use crate::commands::{print_error, print_info, print_json, print_success, print_table_header};
 use crate::{Result, SettingsClient};
 use clap::Subcommand;
 use colored::Colorize;
@@ -47,53 +47,45 @@ async fn get_socs(client: &SettingsClient) -> Result<()> {
 
     match client.get("/api/v1/socs").await {
         Ok(socs) => {
-            println!("\n{}", "SoCs".bold());
-            println!("{}", "=".repeat(50));
+            print_table_header("SoCs", &[
+                ("ID", 24),
+                ("NODES", 10),
+            ]);
 
             // Look for "socs" array in the response
             if let Some(socs_array) = socs.get("socs").and_then(|s| s.as_array()) {
                 if socs_array.is_empty() {
                     println!("No SoCs found.");
                 } else {
-                    for (i, soc) in socs_array.iter().enumerate() {
-                        println!("{}. SoC:", i + 1);
-                        if let Some(id) = soc.get("soc_id") {
-                            println!("   ID: {}", id.as_str().unwrap_or("Unknown"));
-                        }
-                        if let Some(status) = soc.get("status") {
-                            println!("   Status: {}", status.as_str().unwrap_or("Unknown"));
-                        }
+                    // Print each SoC
+                    for soc in socs_array.iter() {
+                        let id = soc.get("soc_id").and_then(|i| i.as_str()).unwrap_or("Unknown");
+                        let node_count = soc.get("nodes")
+                            .and_then(|n| n.as_array())
+                            .map(|arr| arr.len())
+                            .unwrap_or(0);
 
-                        // Show aggregated resource info
-                        if let Some(total_cpu_usage) = soc.get("total_cpu_usage") {
-                            println!(
-                                "   Total CPU Usage: {:.2}%",
-                                total_cpu_usage.as_f64().unwrap_or(0.0)
-                            );
-                        }
-
-                        if let Some(total_mem_usage) = soc.get("total_mem_usage") {
-                            println!(
-                                "   Total Memory Usage: {:.2}%",
-                                total_mem_usage.as_f64().unwrap_or(0.0)
-                            );
-                        }
-
-                        if let Some(nodes) = soc.get("nodes").and_then(|n| n.as_array()) {
-                            println!("   Nodes: {}", nodes.len());
-                        }
-
-                        println!();
+                        println!(
+                            "{:<24} {:<10}",
+                            id, node_count
+                        );
                     }
                 }
             } else if let Some(id) = socs.get("soc_id") {
                 // Single SoC response
-                println!("SoC ID: {}", id.as_str().unwrap_or("Unknown"));
-                if let Some(status) = socs.get("status") {
-                    println!("Status: {}", status.as_str().unwrap_or("Unknown"));
-                }
+                let node_count = socs.get("nodes")
+                    .and_then(|n| n.as_array())
+                    .map(|arr| arr.len())
+                    .unwrap_or(0);
+                println!(
+                    "{:<24} {:<10}",
+                    id.as_str().unwrap_or("Unknown"), node_count
+                );
+            } else {
+                println!("No SoCs found.");
             }
 
+            println!();
             print_success("SoCs list retrieved successfully");
         }
         Err(e) => {

--- a/src/tools/settingscli/src/commands/top.rs
+++ b/src/tools/settingscli/src/commands/top.rs
@@ -70,7 +70,7 @@ async fn top_metrics(client: &SettingsClient) -> Result<()> {
     // Print table header
     println!();
     println!(
-        "{:<6} {:<16} {:<5} {:<6} {:<18} {:<6} {:<4} {:<8} {:<14} {:<14}",
+        "{:<6} {:<15} {:<3} {:<5} {:<19} {:<5} {:<3} {:<7} {:<17} {:<21}",
         "LEVEL".bold(),
         "NAME/ID".bold(),
         "CPU".bold(),
@@ -86,7 +86,7 @@ async fn top_metrics(client: &SettingsClient) -> Result<()> {
     // Print each metric row
     for metric in metrics_data {
         println!(
-            "{:<6} {:<16} {:<5} {:<6} {:<18} {:<6} {:<4} {:<8} {:<14} {:<14}",
+            "{:<6} {:<15} {:<3} {:<5} {:<19} {:<5} {:<3} {:<7} {:<17} {:<21}",
             metric.level,
             metric.name,
             metric.cpu,
@@ -310,22 +310,22 @@ impl MetricRow {
             .to_string();
 
         let network_rx = node
-            .get("network_rx")
+            .get("rx_bytes")
             .and_then(|v| v.as_u64())
             .unwrap_or(0);
 
         let network_tx = node
-            .get("network_tx")
+            .get("tx_bytes")
             .and_then(|v| v.as_u64())
             .unwrap_or(0);
 
         let disk_read = node
-            .get("disk_read")
+            .get("read_bytes")
             .and_then(|v| v.as_u64())
             .unwrap_or(0);
 
         let disk_write = node
-            .get("disk_write")
+            .get("write_bytes")
             .and_then(|v| v.as_u64())
             .unwrap_or(0);
 

--- a/src/tools/settingscli/src/commands/yaml.rs
+++ b/src/tools/settingscli/src/commands/yaml.rs
@@ -41,12 +41,9 @@ async fn apply_yaml(client: &SettingsClient, file_path: &str) -> Result<()> {
 
     match client.post_yaml("/api/artifact", &yaml_content).await {
         Ok(response) => {
-            println!("\n{}", "YAML Artifact Applied".bold());
-            println!("{}", "=".repeat(50));
-
             if let Some(message) = response.get("message") {
                 println!(
-                    "Message: {}",
+                    "{}",
                     message.as_str().unwrap_or("Applied successfully")
                 );
             }
@@ -91,12 +88,9 @@ async fn withdraw_yaml(client: &SettingsClient, file_path: &str) -> Result<()> {
 
     match client.delete_yaml("/api/artifact", &yaml_content).await {
         Ok(response) => {
-            println!("\n{}", "YAML Artifact Withdrawn".bold());
-            println!("{}", "=".repeat(50));
-
             if let Some(message) = response.get("message") {
                 println!(
-                    "Message: {}",
+                    "{}",
                     message.as_str().unwrap_or("Withdrawn successfully")
                 );
             }


### PR DESCRIPTION
- Simplify get commands table output (remove title and separators)
- Add print_table_header() helper function to reduce code duplication
- Refactor board/node/soc/container get commands to use helper
- Simplify yaml apply/withdraw output (remove bold titles and separators)
- Fix Node metric field names in top.rs (network_rx->rx_bytes, disk_read->read_bytes)
- All outputs now follow consistent kubectl-style formatting