### PR TITLE
[resource manager] Add Path 2 resource injection for Scenario Pod

### DIFF
--- a/containers/devonly/scripts/piccolo-server.sh
+++ b/containers/devonly/scripts/piccolo-server.sh
@@ -79,3 +79,13 @@ podman run -d \
   -v /run/piccololog/:/run/piccololog/ \
   ${CONTAINER_IMAGE} \
   /piccolo/settingsservice --bind-address=${MASTER_IP} --bind-port=8080 --log-level=debug
+
+# Run resourcemanager container
+podman run -d \
+  --pod piccolo-server \
+  --name piccolo-resourcemanager \
+  -e ROCKSDB_SERVICE_URL="http://${MASTER_IP}:47007" \
+  -v /etc/piccolo/settings.yaml:/etc/piccolo/settings.yaml:Z \
+  -v /run/piccololog/:/run/piccololog/ \
+  ${CONTAINER_IMAGE} \
+  /piccolo/resourcemanager

--- a/examples/resource_test.sh
+++ b/examples/resource_test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2024 LG Electronics Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+
+BODY=$(< ./resources/network-volume-example.yaml)
+# BODY=$(< ./resources/helloworld_resource.yaml)
+URL="http://192.168.50.112:47099/api/artifact"
+
+curl -X POST "${URL}" \
+--header 'Content-Type: text/plain' \
+--data "${BODY}"

--- a/examples/resources/helloworld_resource.yaml
+++ b/examples/resources/helloworld_resource.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright 2024 LG Electronics Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Scenario
+metadata:
+  name: helloworld
+spec:
+  condition: null
+  action: launch
+  target: helloworld
+---
+apiVersion: v1
+kind: Package
+metadata:
+  label: null
+  name: helloworld
+spec:
+  pattern:
+    - type: plain
+  models:
+    - name: helloworld
+      node: lge
+      resources:
+        volume: app-data-volume
+        network: vehicle-network
+---
+apiVersion: v1
+kind: Model
+metadata:
+  name: helloworld
+  annotations:
+    io.piccolo.annotations.package-type: helloworld
+    io.piccolo.annotations.package-name: helloworld
+    io.piccolo.annotations.package-network: default
+  labels:
+    app: helloworld
+spec:
+  containers:
+    - name: helloworld
+      image: docker.io/library/alpine:latest
+  terminationGracePeriodSeconds: 0

--- a/examples/resources/network-volume-example.yaml
+++ b/examples/resources/network-volume-example.yaml
@@ -15,6 +15,6 @@ metadata:
   name: app-data-volume
 spec:
   volumeName: app-data-volume
-  capacity: 10Gi
+  capacity: 1Gi
   mountPath: /var/app/data
   asilLevel: D

--- a/src/agent/nodeagent/src/runtime/podman/container.rs
+++ b/src/agent/nodeagent/src/runtime/podman/container.rs
@@ -87,22 +87,27 @@ fn build_host_config(
         }
     }
 
-    // Mounts (volumeMounts → Mounts)
+    // Mounts (volumeMounts → Mounts array for Podman API v4.0 compat)
     if let Some(volume_mounts) = container["volumeMounts"].as_array() {
         if let Some(volumes) = spec["volumes"].as_array() {
-            let mut mounts = Vec::new();
+            let mut mounts: Vec<serde_json::Value> = Vec::new();
             for mount in volume_mounts {
                 let mount_name = mount["name"].as_str().unwrap_or("");
                 let mount_path = mount["mountPath"].as_str().unwrap_or("");
                 for volume in volumes {
                     if volume["name"].as_str() == Some(mount_name) {
-                        if let Some(host_path) = volume["hostPath"]["path"].as_str() {
-                            mounts.push(json!({
-                                "Type": "bind",
-                                "Source": host_path,
-                                "Target": mount_path
-                            }));
-                        }
+                        // hostPath가 있으면 hostPath를 Source로, 없으면 mountPath를 Source로 사용
+                        let source = if let Some(host_path) = volume["hostPath"]["path"].as_str() {
+                            host_path
+                        } else {
+                            // hostPath 정보가 없으면 mountPath를 그대로 사용
+                            mount_path
+                        };
+                        mounts.push(json!({
+                            "Type": "bind",
+                            "Source": source,
+                            "Target": mount_path
+                        }));
                         break;
                     }
                 }
@@ -114,6 +119,16 @@ fn build_host_config(
     }
 
     json!(host_config)
+}
+
+/// Get network mode for container creation (Docker-compatible API)
+/// Returns the first network name from spec, or None if not specified
+fn get_network_mode(spec: &serde_json::Value) -> Option<String> {
+    spec["networks"]
+        .as_array()
+        .and_then(|networks| networks.first())
+        .and_then(|network| network["name"].as_str())
+        .map(|s| s.to_string())
 }
 
 /// Build environment variables array
@@ -177,7 +192,18 @@ async fn create_container(
     });
 
     // Add HostConfig
-    let host_config = build_host_config(container, spec, host_network);
+    let mut host_config = build_host_config(container, spec, host_network);
+    
+    // Add NetworkMode to HostConfig (Docker-compatible API)
+    if !host_network {
+        if let Some(network_mode) = get_network_mode(spec) {
+            host_config
+                .as_object_mut()
+                .unwrap()
+                .insert("NetworkMode".to_string(), json!(network_mode));
+        }
+    }
+    
     if !host_config.as_object().unwrap().is_empty() {
         create_body["HostConfig"] = host_config;
     }

--- a/src/common/proto/actioncontroller.proto
+++ b/src/common/proto/actioncontroller.proto
@@ -10,7 +10,6 @@ package actioncontroller;
 service ActionControllerConnection {
   rpc TriggerAction(TriggerActionRequest) returns (TriggerActionResponse);
   rpc Reconcile(ReconcileRequest) returns (ReconcileResponse);
-  rpc CompleteNetworkSetting(CompleteNetworkSettingRequest) returns (CompleteNetworkSettingResponse);
 }
 
 message TriggerActionRequest {
@@ -31,22 +30,6 @@ message ReconcileRequest {
 message ReconcileResponse {
   int32 status = 1;
   string desc = 2;
-}
-
-message CompleteNetworkSettingRequest {
-  string request_id = 1;
-  NetworkStatus network_status = 2;
-  PodStatus pod_status = 3;
-  string details = 4;
-}
-message CompleteNetworkSettingResponse {
-  bool acknowledged = 1;
-}
- 
-enum NetworkStatus {
-  OK = 0;
-  ERROR = 1;
-  TIMEOUT = 2;
 }
 
 enum PodStatus {

--- a/src/common/src/spec/k8s/mod.rs
+++ b/src/common/src/spec/k8s/mod.rs
@@ -2,10 +2,12 @@
 
 pub mod pod;
 
+pub use pod::{PodNetwork, PodSpec, Volume, VolumeMount};
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct Pod {
     apiVersion: String,
     kind: String,
     metadata: super::MetaData,
-    spec: pod::PodSpec,
+    pub spec: pod::PodSpec,
 }

--- a/src/common/src/spec/k8s/pod.rs
+++ b/src/common/src/spec/k8s/pod.rs
@@ -43,6 +43,7 @@ impl From<Model> for Pod {
 pub struct PodSpec {
     hostNetwork: Option<bool>,
     pub containers: Vec<Container>,
+    pub networks: Option<Vec<PodNetwork>>,
     pub volumes: Option<Vec<Volume>>,
     initContainers: Option<Vec<Container>>,
     restartPolicy: Option<String>,
@@ -134,19 +135,24 @@ pub struct PodSecurityContext {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct Volume {
-    name: String,
-    hostPath: HostPath,
+    pub name: String,
+    pub hostPath: Option<HostPath>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct PodNetwork {
+    pub name: String,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct HostPath {
-    path: String,
+    pub path: String,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct VolumeMount {
-    name: String,
-    mountPath: String,
+    pub name: String,
+    pub mountPath: String,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
@@ -204,6 +210,50 @@ impl PodSpec {
 
     pub fn get_volume(&mut self) -> &Option<Vec<Volume>> {
         &self.volumes
+    }
+
+    /// Adds a network to the pod spec
+    pub fn add_network(&mut self, network_name: &str) {
+        let network = PodNetwork {
+            name: network_name.to_string(),
+        };
+        match &mut self.networks {
+            Some(networks) => networks.push(network),
+            None => self.networks = Some(vec![network]),
+        }
+    }
+
+    /// Adds a volume to the pod spec
+    pub fn add_volume(&mut self, volume: Volume) {
+        match &mut self.volumes {
+            Some(volumes) => volumes.push(volume),
+            None => self.volumes = Some(vec![volume]),
+        }
+    }
+
+    /// Adds a volume mount to all containers in the pod
+    pub fn add_volume_mount(&mut self, volume_name: &str, mount_path: &str) {
+        let volume_mount = VolumeMount {
+            name: volume_name.to_string(),
+            mountPath: mount_path.to_string(),
+        };
+
+        for container in &mut self.containers {
+            match &mut container.volumeMounts {
+                Some(mounts) => mounts.push(volume_mount.clone()),
+                None => container.volumeMounts = Some(vec![volume_mount.clone()]),
+            }
+        }
+    }
+
+    /// Adds a volume mount to the first container
+    pub fn add_volume_mount_to_first_container(&mut self, volume_mount: VolumeMount) {
+        if let Some(container) = self.containers.first_mut() {
+            match &mut container.volumeMounts {
+                Some(mounts) => mounts.push(volume_mount),
+                None => container.volumeMounts = Some(vec![volume_mount]),
+            }
+        }
     }
 }
 

--- a/src/player/actioncontroller/src/grpc/receiver.rs
+++ b/src/player/actioncontroller/src/grpc/receiver.rs
@@ -11,8 +11,8 @@ use common::actioncontroller::{
     action_controller_connection_server::{
         ActionControllerConnection, ActionControllerConnectionServer,
     },
-    CompleteNetworkSettingRequest, CompleteNetworkSettingResponse, PodStatus as ActionStatus,
-    ReconcileRequest, ReconcileResponse, TriggerActionRequest, TriggerActionResponse,
+    PodStatus as ActionStatus, ReconcileRequest, ReconcileResponse, TriggerActionRequest,
+    TriggerActionResponse,
 };
 use common::logd;
 
@@ -174,20 +174,6 @@ impl ActionControllerConnection for ActionControllerReceiver {
                 Err(Status::internal(format!("Failed to reconcile: {}", e)))
             }
         }
-    }
-
-    async fn complete_network_setting(
-        &self,
-        request: Request<CompleteNetworkSettingRequest>,
-    ) -> Result<Response<CompleteNetworkSettingResponse>, Status> {
-        let req = request.into_inner();
-        logd!(2,
-            "CompleteNetworkSettingRequest: request_id={}, network_status={:?}, pod_status={:?}, details={}",
-            req.request_id, req.network_status, req.pod_status, req.details
-        );
-
-        let response = CompleteNetworkSettingResponse { acknowledged: true };
-        Ok(Response::new(response))
     }
 }
 

--- a/src/player/actioncontroller/src/manager.rs
+++ b/src/player/actioncontroller/src/manager.rs
@@ -9,8 +9,13 @@ use crate::grpc::sender::statemanager::StateManagerSender;
 use common::logd;
 use common::{
     actioncontroller::PodStatus as Status,
-    spec::artifact::{
-        package::ModelInfo, schedule::SchedPolicy, Artifact, Package, Scenario, Schedule,
+    spec::{
+        artifact::{
+            package::ModelInfo, schedule::SchedPolicy, Artifact, Package, Scenario, Schedule,
+            Volume as VolumeResource,
+        },
+        k8s::{Pod, Volume},
+        k8s::pod::HostPath,
     },
     statemanager::{ResourceType, StateChange},
     Result,
@@ -21,6 +26,7 @@ const ETCD_SCENARIO_PREFIX: &str = "Scenario";
 const ETCD_PACKAGE_PREFIX: &str = "Package";
 const ETCD_POD_PREFIX: &str = "Pod";
 const ETCD_NETWORK_PREFIX: &str = "Network";
+const ETCD_VOLUME_PREFIX: &str = "Volume";
 const ETCD_NODE_PREFIX: &str = "Node";
 const ETCD_NODES_PREFIX: &str = "nodes";
 const ETCD_SCHED_PREFIX: &str = "Schedule";
@@ -220,7 +226,10 @@ impl ActionControllerManager {
     ) -> Result<()> {
         let model_name = model_info.get_name();
         let model_node = model_info.get_node();
-        let pod = common::etcd::get(&format!("{}/{}", ETCD_POD_PREFIX, model_name)).await?;
+        let pod_yaml = common::etcd::get(&format!("{}/{}", ETCD_POD_PREFIX, model_name)).await?;
+
+        // Inject resources from Package.models[].resources into Pod
+        let pod = self.inject_resources_into_pod(&pod_yaml, model_info).await?;
 
         match action {
             "launch" => {
@@ -354,6 +363,92 @@ impl ActionControllerManager {
             }
         }
         Ok(())
+    }
+
+    /// Inject resources (networks and volumes) into a pod specification
+    ///
+    /// This method modifies the PodSpec by adding network configurations
+    /// and volume mounts based on the resource definitions from Package.models[].resources.
+    ///
+    /// # Arguments
+    ///
+    /// * `pod_yaml` - The original pod YAML string from ETCD
+    /// * `model_info` - ModelInfo containing resource references (network, volume names)
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(String)` - The modified pod YAML with injected resources
+    /// * `Err(...)` - If parsing or injection fails
+    async fn inject_resources_into_pod(
+        &self,
+        pod_yaml: &str,
+        model_info: &ModelInfo,
+    ) -> Result<String> {
+        let resources = model_info.get_resources();
+        let network_name = resources.get_network();
+        let volume_name = resources.get_volume();
+
+        // If no resources to inject, return original
+        if network_name.is_none() && volume_name.is_none() {
+            return Ok(pod_yaml.to_string());
+        }
+
+        // Parse Pod YAML
+        let mut pod: Pod = serde_yaml::from_str(pod_yaml)
+            .map_err(|e| format!("Failed to parse Pod YAML: {}", e))?;
+
+        // Inject network if specified
+        if let Some(net_name) = network_name {
+            logd!(
+                2,
+                "Injecting network '{}' into pod '{}'",
+                net_name,
+                pod.get_name()
+            );
+            pod.spec.add_network(&net_name);
+        }
+
+        // Inject volume if specified
+        if let Some(vol_name) = &volume_name {
+            logd!(
+                2,
+                "Injecting volume '{}' into pod '{}'",
+                vol_name,
+                pod.get_name()
+            );
+
+            // Fetch Volume resource from ETCD to get mountPath
+            let volume_key = format!("{}/{}", ETCD_VOLUME_PREFIX, vol_name);
+            let volume_yaml = common::etcd::get(&volume_key)
+                .await
+                .map_err(|e| format!("Failed to get Volume '{}' from ETCD: {}", vol_name, e))?;
+
+            let volume_resource: VolumeResource = serde_yaml::from_str(&volume_yaml)
+                .map_err(|e| format!("Failed to parse Volume '{}': {}", vol_name, e))?;
+
+            let mount_path = volume_resource.get_spec().get_mount_path();
+            logd!(2, "Volume '{}' mountPath: {}", vol_name, mount_path);
+
+            // Create a hostPath volume entry using mountPath as the host path
+            let volume = Volume {
+                name: vol_name.clone(),
+                hostPath: Some(HostPath {
+                    path: mount_path.to_string(),
+                }),
+            };
+
+            // Add volume to pod spec
+            pod.spec.add_volume(volume);
+
+            // Add volumeMount to all containers
+            pod.spec.add_volume_mount(vol_name, mount_path);
+        }
+
+        // Serialize back to YAML
+        let modified_yaml = serde_yaml::to_string(&pod)
+            .map_err(|e| format!("Failed to serialize modified Pod: {}", e))?;
+
+        Ok(modified_yaml)
     }
 
     /// Processes a trigger action request for a specific scenario

--- a/src/player/filtergateway/src/grpc/sender/actioncontroller.rs
+++ b/src/player/filtergateway/src/grpc/sender/actioncontroller.rs
@@ -64,8 +64,6 @@ impl FilterGatewaySender {
 mod tests {
     use super::*;
     use anyhow::Error;
-    use common::actioncontroller::CompleteNetworkSettingRequest;
-    use common::actioncontroller::CompleteNetworkSettingResponse;
     use common::actioncontroller::{
         action_controller_connection_server::{
             ActionControllerConnection, ActionControllerConnectionServer,
@@ -107,15 +105,6 @@ mod tests {
             _request: Request<ReconcileRequest>,
         ) -> std::result::Result<Response<ReconcileResponse>, Status> {
             Ok(Response::new(ReconcileResponse::default()))
-        }
-
-        async fn complete_network_setting(
-            &self,
-            _request: Request<CompleteNetworkSettingRequest>,
-        ) -> std::result::Result<Response<CompleteNetworkSettingResponse>, Status> {
-            Ok(Response::new(CompleteNetworkSettingResponse {
-                acknowledged: true, // or false, depending on test needs
-            }))
         }
     }
 

--- a/src/player/statemanager/src/manager.rs
+++ b/src/player/statemanager/src/manager.rs
@@ -1278,8 +1278,7 @@ mod integration_tests {
         action_controller_connection_server::{
             ActionControllerConnection, ActionControllerConnectionServer,
         },
-        CompleteNetworkSettingRequest, CompleteNetworkSettingResponse, ReconcileRequest,
-        ReconcileResponse, TriggerActionRequest, TriggerActionResponse,
+        ReconcileRequest, ReconcileResponse, TriggerActionRequest, TriggerActionResponse,
     };
     use std::sync::Arc;
     use tonic::{transport::Server, Request, Response, Status};
@@ -1330,15 +1329,6 @@ mod integration_tests {
             Ok(Response::new(ReconcileResponse {
                 status: 0,
                 desc: "Mock reconcile success".to_string(),
-            }))
-        }
-
-        async fn complete_network_setting(
-            &self,
-            _request: Request<CompleteNetworkSettingRequest>,
-        ) -> std::result::Result<Response<CompleteNetworkSettingResponse>, Status> {
-            Ok(Response::new(CompleteNetworkSettingResponse {
-                acknowledged: true,
             }))
         }
     }


### PR DESCRIPTION
- Inject Network/Volume from Package.models[].resources into Pod
- Add PodNetwork, NamedVolume, update Volume struct in k8s spec
- Add inject_resources_into_pod() in ActionController
- Update NodeAgent for Docker-compatible API (Binds, NetworkMode)
- Remove CompleteNetworkSetting RPC
- Add helloworld_resource.yaml example