### PR TITLE
[resource manager] resource manager 및 podman container 네트워크/HostConfig 처리 개선

### DIFF
--- a/src/agent/nodeagent/src/runtime/podman/container.rs
+++ b/src/agent/nodeagent/src/runtime/podman/container.rs
@@ -47,9 +47,15 @@ fn build_host_config(
 ) -> serde_json::Value {
     let mut host_config = serde_json::Map::new();
 
-    // Add hostNetwork setting
+    // Add network mode setting
     if host_network {
         host_config.insert("NetworkMode".to_string(), json!("host"));
+    } else if let Some(network_name) = spec["networks"]
+        .as_array()
+        .and_then(|networks| networks.first())
+        .and_then(|network| network["name"].as_str())
+    {
+        host_config.insert("NetworkMode".to_string(), json!(network_name));
     }
 
     // CapAdd
@@ -121,16 +127,6 @@ fn build_host_config(
     json!(host_config)
 }
 
-/// Get network mode for container creation (Docker-compatible API)
-/// Returns the first network name from spec, or None if not specified
-fn get_network_mode(spec: &serde_json::Value) -> Option<String> {
-    spec["networks"]
-        .as_array()
-        .and_then(|networks| networks.first())
-        .and_then(|network| network["name"].as_str())
-        .map(|s| s.to_string())
-}
-
 /// Build environment variables array
 fn build_env_vars(container: &serde_json::Value) -> Vec<String> {
     container["env"]
@@ -192,17 +188,7 @@ async fn create_container(
     });
 
     // Add HostConfig
-    let mut host_config = build_host_config(container, spec, host_network);
-    
-    // Add NetworkMode to HostConfig (Docker-compatible API)
-    if !host_network {
-        if let Some(network_mode) = get_network_mode(spec) {
-            host_config
-                .as_object_mut()
-                .unwrap()
-                .insert("NetworkMode".to_string(), json!(network_mode));
-        }
-    }
+    let host_config = build_host_config(container, spec, host_network);
     
     if !host_config.as_object().unwrap().is_empty() {
         create_body["HostConfig"] = host_config;

--- a/src/server/resourcemanager/src/grpc/receiver.rs
+++ b/src/server/resourcemanager/src/grpc/receiver.rs
@@ -3,194 +3,58 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use crate::grpc::sender::csi::CsiSender;
-use crate::grpc::sender::pharos::PharosSender;
-use common::external::csi::{VolumeCreateRequest, VolumeDeleteRequest};
-use common::external::pharos::{NetworkRemoveRequest, NetworkSetupRequest};
-use common::resourcemanager::resource_manager_service_server::ResourceManagerService;
+//! gRPC Receiver module
+//!
+//! This module is responsible for:
+//! - Receiving gRPC requests
+//! - Delegating message processing to ResourceManager
+
+use std::sync::Arc;
+
+use crate::manager::ResourceManager;
+use common::logd;
+use common::resourcemanager::resource_manager_service_server::{
+    ResourceManagerService, ResourceManagerServiceServer,
+};
 use common::resourcemanager::{Action, HandleResourceRequest, HandleResourceResponse};
-use common::spec::artifact::{Network, Volume};
+use tokio::sync::RwLock;
 use tonic::Response;
 
-// Artifact kind constants
-const KIND_NETWORK: &str = "Network";
-const KIND_VOLUME: &str = "Volume";
-
-#[allow(dead_code)]
-pub struct ResourceManagerGrpcServer {
-    /// Pharos sender for network resource operations
-    pharos_sender: PharosSender,
-    /// CSI sender for volume resource operations
-    csi_sender: CsiSender,
+/// Receiver for handling incoming gRPC requests for ResourceManager
+///
+/// Implements the ResourceManagerService gRPC service defined in
+/// the protobuf specification.
+pub struct ResourceManagerReceiver {
+    /// Reference to the ResourceManager
+    manager: Arc<RwLock<ResourceManager>>,
 }
 
-#[allow(dead_code)]
-impl ResourceManagerGrpcServer {
-    /// Creates a new ResourceManagerGrpcServer instance
-    pub fn new() -> Self {
-        Self {
-            pharos_sender: PharosSender::new(),
-            csi_sender: CsiSender::new(),
-        }
+impl ResourceManagerReceiver {
+    /// Create a new ResourceManagerReceiver instance
+    ///
+    /// # Arguments
+    ///
+    /// * `manager` - Shared reference to the ResourceManager
+    ///
+    /// # Returns
+    ///
+    /// A new ResourceManagerReceiver instance
+    pub fn new(manager: Arc<RwLock<ResourceManager>>) -> Self {
+        Self { manager }
     }
 
-    /// Parse YAML and extract artifact kind
-    fn parse_artifact_kind(yaml_str: &str) -> Option<String> {
-        let value: serde_yaml::Value = serde_yaml::from_str(yaml_str).ok()?;
-        value.get("kind")?.as_str().map(|s| s.to_string())
-    }
-
-    /// Process Network resource
-    async fn process_network(
-        &self,
-        yaml_str: &str,
-        action: Action,
-    ) -> Result<HandleResourceResponse, String> {
-        let network: Network = serde_yaml::from_str(yaml_str)
-            .map_err(|e| format!("Failed to parse Network YAML: {}", e))?;
-
-        let spec = network.get_spec();
-        let network_name = spec.get_network_name().to_string();
-        let network_mode = spec.get_network_mode().as_str().to_string();
-
-        println!("RESOURCE MANAGER: Processing Network Resource");
-        println!("  Network Name: {}", &network_name);
-        println!("  Network Mode: {}", &network_mode);
-        println!("  Action: {:?}", action);
-
-        match action {
-            Action::Apply => {
-                let pharos_req = NetworkSetupRequest {
-                    network_name: network_name.clone(),
-                    network_mode,
-                };
-
-                println!("Sending NetworkSetupRequest to Pharos");
-                match self.pharos_sender.clone().setup_network(pharos_req).await {
-                    Ok(response) => {
-                        let resp = response.into_inner();
-                        println!("Successfully created network resource: {}", &network_name);
-                        Ok(HandleResourceResponse {
-                            success: resp.success,
-                            message: resp.message,
-                        })
-                    }
-                    Err(e) => {
-                        println!("Failed to create network resource: {:?}", e);
-                        Ok(HandleResourceResponse {
-                            success: false,
-                            message: format!("Failed to create network resource: {}", e),
-                        })
-                    }
-                }
-            }
-            Action::Withdraw => {
-                let pharos_req = NetworkRemoveRequest {
-                    network_name: network_name.clone(),
-                };
-
-                println!("Sending NetworkRemoveRequest to Pharos");
-                match self.pharos_sender.clone().remove_network(pharos_req).await {
-                    Ok(response) => {
-                        let resp = response.into_inner();
-                        println!("Successfully deleted network resource: {}", &network_name);
-                        Ok(HandleResourceResponse {
-                            success: resp.success,
-                            message: resp.message,
-                        })
-                    }
-                    Err(e) => {
-                        println!("Failed to delete network resource: {:?}", e);
-                        Ok(HandleResourceResponse {
-                            success: false,
-                            message: format!("Failed to delete network resource: {}", e),
-                        })
-                    }
-                }
-            }
-        }
-    }
-
-    /// Process Volume resource
-    async fn process_volume(
-        &self,
-        yaml_str: &str,
-        action: Action,
-    ) -> Result<HandleResourceResponse, String> {
-        let volume: Volume = serde_yaml::from_str(yaml_str)
-            .map_err(|e| format!("Failed to parse Volume YAML: {}", e))?;
-
-        let spec = volume.get_spec();
-        let volume_name = spec.get_volume_name().to_string();
-        let capacity = spec.get_capacity().to_string();
-        let mountpath = spec.get_mount_path().to_string();
-        let asil_level = spec.get_asil_level().as_str().to_string();
-
-        println!("RESOURCE MANAGER: Processing Volume Resource");
-        println!("  Volume Name: {}", &volume_name);
-        println!("  Capacity: {}", &capacity);
-        println!("  Mount Path: {}", &mountpath);
-        println!("  ASIL Level: {}", &asil_level);
-        println!("  Action: {:?}", action);
-
-        match action {
-            Action::Apply => {
-                let csi_req = VolumeCreateRequest {
-                    volume_name: volume_name.clone(),
-                    capacity,
-                    mountpath,
-                    asil_level,
-                };
-
-                println!("Sending VolumeCreateRequest to CSI");
-                match self.csi_sender.clone().create_volume(csi_req).await {
-                    Ok(response) => {
-                        let resp = response.into_inner();
-                        println!("Successfully created volume resource: {}", &volume_name);
-                        Ok(HandleResourceResponse {
-                            success: resp.success,
-                            message: resp.message,
-                        })
-                    }
-                    Err(e) => {
-                        println!("Failed to create volume resource: {:?}", e);
-                        Ok(HandleResourceResponse {
-                            success: false,
-                            message: format!("Failed to create volume resource: {}", e),
-                        })
-                    }
-                }
-            }
-            Action::Withdraw => {
-                let csi_req = VolumeDeleteRequest {
-                    volume_name: volume_name.clone(),
-                };
-
-                println!("Sending VolumeDeleteRequest to CSI");
-                match self.csi_sender.clone().delete_volume(csi_req).await {
-                    Ok(response) => {
-                        let resp = response.into_inner();
-                        println!("Successfully deleted volume resource: {}", &volume_name);
-                        Ok(HandleResourceResponse {
-                            success: resp.success,
-                            message: resp.message,
-                        })
-                    }
-                    Err(e) => {
-                        println!("Failed to delete volume resource: {:?}", e);
-                        Ok(HandleResourceResponse {
-                            success: false,
-                            message: format!("Failed to delete volume resource: {}", e),
-                        })
-                    }
-                }
-            }
-        }
+    /// Get a gRPC server for this receiver
+    ///
+    /// # Returns
+    ///
+    /// A configured ResourceManagerServiceServer
+    pub fn into_service(self) -> ResourceManagerServiceServer<Self> {
+        ResourceManagerServiceServer::new(self)
     }
 }
 
 #[tonic::async_trait]
-impl ResourceManagerService for ResourceManagerGrpcServer {
+impl ResourceManagerService for ResourceManagerReceiver {
     async fn handle_resource(
         &self,
         request: tonic::Request<HandleResourceRequest>,
@@ -199,40 +63,13 @@ impl ResourceManagerService for ResourceManagerGrpcServer {
         let yaml_str = &req.resource_yaml;
         let action = Action::try_from(req.action).unwrap_or(Action::Apply);
 
-        println!("RESOURCE MANAGER: Received resource YAML");
-        println!("  Action: {:?}", action);
+        logd!(1, "GRPC RECEIVER: Received resource request");
+        logd!(2, "  Action: {:?}", action);
 
-        // Parse YAML to determine resource kind
-        let kind = match Self::parse_artifact_kind(yaml_str) {
-            Some(k) => k,
-            None => {
-                return Ok(Response::new(HandleResourceResponse {
-                    success: false,
-                    message: "Failed to parse resource kind from YAML".to_string(),
-                }));
-            }
-        };
+        // Delegate YAML parsing, resource kind determination, and routing to ResourceManager
+        let mut manager = self.manager.write().await;
+        let response = manager.handle_resource(yaml_str, action).await;
 
-        println!("  Resource Kind: {}", &kind);
-
-        // Process based on resource kind
-        let result = match kind.as_str() {
-            KIND_NETWORK => self.process_network(yaml_str, action).await,
-            KIND_VOLUME => self.process_volume(yaml_str, action).await,
-            _ => {
-                return Ok(Response::new(HandleResourceResponse {
-                    success: false,
-                    message: format!("Unsupported resource kind: {}", kind),
-                }));
-            }
-        };
-
-        match result {
-            Ok(response) => Ok(Response::new(response)),
-            Err(e) => Ok(Response::new(HandleResourceResponse {
-                success: false,
-                message: e,
-            })),
-        }
+        Ok(Response::new(response))
     }
 }

--- a/src/server/resourcemanager/src/main.rs
+++ b/src/server/resourcemanager/src/main.rs
@@ -3,27 +3,40 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 pub mod grpc;
+pub mod manager;
 
-use common::resourcemanager::resource_manager_service_server::ResourceManagerServiceServer;
-use grpc::receiver::ResourceManagerGrpcServer;
+use std::sync::Arc;
+
+use common::logd;
+use common::logd::logger;
+use grpc::receiver::ResourceManagerReceiver;
+use manager::ResourceManager;
+use tokio::sync::RwLock;
 use tonic::transport::Server;
 
 #[tokio::main]
 async fn main() {
-    println!("Starting Resource Manager...");
+    // Initialize async logger for logd! macro
+    let _ = logger::init_async_logger("resourcemanager").await;
 
-    let server = ResourceManagerGrpcServer::new();
+    logd!(1, "Starting Resource Manager...");
+
+    // Create ResourceManager and wrap in Arc<RwLock> for shared mutable ownership
+    let manager = Arc::new(RwLock::new(ResourceManager::new()));
+
+    // Create receiver with injected manager
+    let receiver = ResourceManagerReceiver::new(manager);
 
     let addr = common::resourcemanager::open_server()
         .parse()
         .expect("resourcemanager address parsing error");
-    println!("ResourceManager gRPC server listening on {}", addr);
+    logd!(1, "ResourceManager gRPC server listening on {}", addr);
 
     if let Err(e) = Server::builder()
-        .add_service(ResourceManagerServiceServer::new(server))
+        .add_service(receiver.into_service())
         .serve(addr)
         .await
     {
-        println!("gRPC server error: {}", e);
+        logd!(5, "gRPC server error: {}", e);
     }
 }

--- a/src/server/resourcemanager/src/manager.rs
+++ b/src/server/resourcemanager/src/manager.rs
@@ -1,0 +1,238 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2024 LG Electronics Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Resource Manager module
+//!
+//! This module is responsible for:
+//! - Parsing and validating resource YAML
+//! - Determining resource kind
+//! - Routing requests to appropriate handlers based on resource kind
+
+use crate::grpc::sender::csi::CsiSender;
+use crate::grpc::sender::pharos::PharosSender;
+use common::external::csi::{VolumeCreateRequest, VolumeDeleteRequest};
+use common::external::pharos::{NetworkRemoveRequest, NetworkSetupRequest};
+use common::logd;
+use common::resourcemanager::{Action, HandleResourceResponse};
+use common::spec::artifact::{Network, Volume};
+
+// Artifact kind constants
+const KIND_NETWORK: &str = "Network";
+const KIND_VOLUME: &str = "Volume";
+
+/// ResourceManager handles YAML parsing, resource kind determination, and request routing
+pub struct ResourceManager {
+    /// Pharos sender for network resource operations
+    pharos_sender: PharosSender,
+    /// CSI sender for volume resource operations
+    csi_sender: CsiSender,
+}
+
+impl Default for ResourceManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ResourceManager {
+    /// Creates a new ResourceManager instance
+    pub fn new() -> Self {
+        Self {
+            pharos_sender: PharosSender::new(),
+            csi_sender: CsiSender::new(),
+        }
+    }
+
+    /// Parse YAML and extract artifact kind
+    fn parse_artifact_kind(yaml_str: &str) -> Option<String> {
+        let value: serde_yaml::Value = serde_yaml::from_str(yaml_str).ok()?;
+        value.get("kind")?.as_str().map(|s| s.to_string())
+    }
+
+    /// Helper function to create success response
+    fn success_response(success: bool, message: String) -> HandleResourceResponse {
+        HandleResourceResponse { success, message }
+    }
+
+    /// Helper function to create error response
+    fn error_response(message: String) -> HandleResourceResponse {
+        HandleResourceResponse {
+            success: false,
+            message,
+        }
+    }
+
+    /// Handle resource request: parse YAML, determine kind, and route to appropriate handler
+    pub async fn handle_resource(
+        &mut self,
+        yaml_str: &str,
+        action: Action,
+    ) -> HandleResourceResponse {
+        logd!(1, "RESOURCE MANAGER: Processing resource request");
+        logd!(2, "  Action: {:?}", action);
+
+        // Parse YAML to determine resource kind
+        let kind = match Self::parse_artifact_kind(yaml_str) {
+            Some(k) => k,
+            None => {
+                return Self::error_response(
+                    "Failed to parse resource kind from YAML".to_string(),
+                );
+            }
+        };
+
+        logd!(2, "  Resource Kind: {}", &kind);
+
+        // Route to appropriate handler based on resource kind
+        let result = match kind.as_str() {
+            KIND_NETWORK => self.process_network(yaml_str, action).await,
+            KIND_VOLUME => self.process_volume(yaml_str, action).await,
+            _ => {
+                return Self::error_response(format!("Unsupported resource kind: {}", kind));
+            }
+        };
+
+        match result {
+            Ok(response) => response,
+            Err(e) => Self::error_response(e),
+        }
+    }
+
+    /// Process Network resource
+    async fn process_network(
+        &mut self,
+        yaml_str: &str,
+        action: Action,
+    ) -> Result<HandleResourceResponse, String> {
+        let network: Network = serde_yaml::from_str(yaml_str)
+            .map_err(|e| format!("Failed to parse Network YAML: {}", e))?;
+
+        let spec = network.get_spec();
+        let network_name = spec.get_network_name().to_string();
+        let network_mode = spec.get_network_mode().as_str().to_string();
+
+        logd!(1, "RESOURCE MANAGER: Processing Network Resource");
+        logd!(2, "  Network Name: {}", &network_name);
+        logd!(2, "  Network Mode: {}", &network_mode);
+        logd!(2, "  Action: {:?}", action);
+
+        match action {
+            Action::Apply => {
+                let pharos_req = NetworkSetupRequest {
+                    network_name: network_name.clone(),
+                    network_mode,
+                };
+
+                logd!(2, "Sending NetworkSetupRequest to Pharos");
+                match self.pharos_sender.setup_network(pharos_req).await {
+                    Ok(response) => {
+                        let resp = response.into_inner();
+                        logd!(1, "Successfully created network resource: {}", &network_name);
+                        Ok(Self::success_response(resp.success, resp.message))
+                    }
+                    Err(e) => {
+                        logd!(4, "Failed to create network resource: {:?}", e);
+                        Ok(Self::error_response(format!(
+                            "Failed to create network resource: {}",
+                            e
+                        )))
+                    }
+                }
+            }
+            Action::Withdraw => {
+                let pharos_req = NetworkRemoveRequest {
+                    network_name: network_name.clone(),
+                };
+
+                logd!(2, "Sending NetworkRemoveRequest to Pharos");
+                match self.pharos_sender.remove_network(pharos_req).await {
+                    Ok(response) => {
+                        let resp = response.into_inner();
+                        logd!(1, "Successfully deleted network resource: {}", &network_name);
+                        Ok(Self::success_response(resp.success, resp.message))
+                    }
+                    Err(e) => {
+                        logd!(4, "Failed to delete network resource: {:?}", e);
+                        Ok(Self::error_response(format!(
+                            "Failed to delete network resource: {}",
+                            e
+                        )))
+                    }
+                }
+            }
+        }
+    }
+
+    /// Process Volume resource
+    async fn process_volume(
+        &mut self,
+        yaml_str: &str,
+        action: Action,
+    ) -> Result<HandleResourceResponse, String> {
+        let volume: Volume = serde_yaml::from_str(yaml_str)
+            .map_err(|e| format!("Failed to parse Volume YAML: {}", e))?;
+
+        let spec = volume.get_spec();
+        let volume_name = spec.get_volume_name().to_string();
+        let capacity = spec.get_capacity().to_string();
+        let mountpath = spec.get_mount_path().to_string();
+        let asil_level = spec.get_asil_level().as_str().to_string();
+
+        logd!(1, "RESOURCE MANAGER: Processing Volume Resource");
+        logd!(2, "  Volume Name: {}", &volume_name);
+        logd!(2, "  Capacity: {}", &capacity);
+        logd!(2, "  Mount Path: {}", &mountpath);
+        logd!(2, "  ASIL Level: {}", &asil_level);
+        logd!(2, "  Action: {:?}", action);
+
+        match action {
+            Action::Apply => {
+                let csi_req = VolumeCreateRequest {
+                    volume_name: volume_name.clone(),
+                    capacity,
+                    mountpath,
+                    asil_level,
+                };
+
+                logd!(2, "Sending VolumeCreateRequest to CSI");
+                match self.csi_sender.create_volume(csi_req).await {
+                    Ok(response) => {
+                        let resp = response.into_inner();
+                        logd!(1, "Successfully created volume resource: {}", &volume_name);
+                        Ok(Self::success_response(resp.success, resp.message))
+                    }
+                    Err(e) => {
+                        logd!(4, "Failed to create volume resource: {:?}", e);
+                        Ok(Self::error_response(format!(
+                            "Failed to create volume resource: {}",
+                            e
+                        )))
+                    }
+                }
+            }
+            Action::Withdraw => {
+                let csi_req = VolumeDeleteRequest {
+                    volume_name: volume_name.clone(),
+                };
+
+                logd!(2, "Sending VolumeDeleteRequest to CSI");
+                match self.csi_sender.delete_volume(csi_req).await {
+                    Ok(response) => {
+                        let resp = response.into_inner();
+                        logd!(1, "Successfully deleted volume resource: {}", &volume_name);
+                        Ok(Self::success_response(resp.success, resp.message))
+                    }
+                    Err(e) => {
+                        logd!(4, "Failed to delete volume resource: {:?}", e);
+                        Ok(Self::error_response(format!(
+                            "Failed to delete volume resource: {}",
+                            e
+                        )))
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
ResourceManager 구조 분리

manager.rs 파일 신설: YAML 파싱, 리소스 종류 판별, 요청 라우팅, 실제 네트워크/볼륨 처리 로직을 ResourceManager로 이동
gRPC receiver는 요청을 받아 ResourceManager에 위임하는 구조로 변경
gRPC Receiver 리팩토링

기존의 ResourceManagerGrpcServer → ResourceManagerReceiver로 변경
내부적으로 Arc<RwLock<ResourceManager>>를 주입받아 사용 (의존성 주입)
gRPC 요청 처리 시 직접 분기하지 않고 ResourceManager에 위임
네트워크/HostConfig 처리 개선

네트워크 이름 추출 및 HostConfig에 NetworkMode 설정 로직 개선
관련 중복 함수 제거 및 코드 단순화
로깅 개선

println 대신 logd! 매크로 사용, 비동기 logger 도입
로그 레벨별로 상세 정보 출력
불필요/중복 코드 제거 및 주석, 문서화 강화