### PR TITLE
Update image source path for Pullpiri logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <div align="center">
-    <img alt="Shows Pullpiri logo" src="doc/images/pullpiri_brightmode.png"
+    <img alt="Shows Pullpiri logo" src="doc/assets/logo/pullpiri_brightmode.png"
         width="50%"
     />
 </div>


### PR DESCRIPTION
This pull request makes a minor update to the `README.md` file by changing the logo image path to point to the new location in the `doc/assets/logo` directory.