### PR TITLE
update Pullpiri logo image path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <div align="center">
-    <img alt="Shows Pullpiri logo" src="doc/images/pullpiri_brightmode.png"
+    <img alt="Shows Pullpiri logo" src="doc/assets/pullpiri_brightmode.png"
         width="50%"
     />
 </div>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <div align="center">
-    <img alt="Shows Pullpiri logo" src="doc/assets/pullpiri_brightmode.png"
+    <img alt="Shows Pullpiri logo" src="doc/assets/logo/pullpiri_brightmode.png"
         width="50%"
     />
 </div>


### PR DESCRIPTION

## Summary

Fix the Pullpiri logo image path in README to reflect the current asset location.

## Changes

- Updated the Pullpiri logo image reference in README
- Changed the logo path from `doc/images/` to `doc/assets/`
- Ensured the logo is displayed correctly in the project documentation

## Related Issue

Closes #486
