### PR TITLE
feat: dynamic resource scaling with millicore CPU and server-side val…

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -74,6 +74,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
 COPY --from=builder /pullpiri/target/release/apiserver /pullpiri/
 COPY --from=builder /pullpiri/target/release/monitoringserver /pullpiri/
 COPY --from=builder /pullpiri/target/release/policymanager /pullpiri/
+COPY --from=builder /pullpiri/target/release/resourcemanager /pullpiri/
 COPY --from=builder /pullpiri/target/release/settingsservice /pullpiri/
 COPY --from=builder /pullpiri/target/release/logservice /pullpiri/
 #COPY --from=builder /pullpiri/target/release/nodeagent /pullpiri/

--- a/containers/devonly/scripts/pullpiri-server.sh
+++ b/containers/devonly/scripts/pullpiri-server.sh
@@ -51,6 +51,16 @@ podman run -d \
   ${CONTAINER_IMAGE} \
   /pullpiri/policymanager
 
+# Run resourcemanager container (Dynamic Resource Scaling, #514 / #526)
+podman run -d \
+  --pod pullpiri-server \
+  --name pullpiri-resourcemanager \
+  -e ROCKSDB_SERVICE_URL="http://${MASTER_IP}:47007" \
+  -v /etc/pullpiri/settings.yaml:/etc/pullpiri/settings.yaml:Z \
+  -v /run/pullpirilog/:/run/pullpirilog/ \
+  ${CONTAINER_IMAGE} \
+  /pullpiri/resourcemanager
+
 # Run monitoringserver container
 podman run -d \
   --pod pullpiri-server \

--- a/containers/scripts/pullpiri-server.sh
+++ b/containers/scripts/pullpiri-server.sh
@@ -54,6 +54,16 @@ podman run -d \
   ${CONTAINER_IMAGE} \
   /pullpiri/policymanager
 
+# Run resourcemanager container (Dynamic Resource Scaling, #514 / #526)
+podman run -d \
+  --pod pullpiri-server \
+  --name pullpiri-resourcemanager \
+  -e ROCKSDB_SERVICE_URL="http://${MASTER_IP}:47007" \
+  -v /etc/pullpiri/settings.yaml:/etc/pullpiri/settings.yaml:Z \
+  -v /run/pullpirilog/:/run/pullpirilog/ \
+  ${CONTAINER_IMAGE} \
+  /pullpiri/resourcemanager
+
 # Run monitoringserver container
 podman run -d \
   --pod pullpiri-server \

--- a/scripts/e2e_dynamic_resource_scaling.sh
+++ b/scripts/e2e_dynamic_resource_scaling.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Dynamic Resource Scaling - full-stack end-to-end test (#514 / #526)
+#
+# Brings up the real pullpiri components involved in the scaling path and
+# drives a scaling request through them, exactly as production would:
+#
+#   scaling_client --RequestResourceScaling--> ActionController (47001, container)
+#        -> ResourceManager   (47008, container)   validate / desired / reconcile
+#        -> NodeAgent         (47004, host binary)  Podman libpod update
+#        -> target container cgroup (cpu.max / memory.max)   <-- authoritative check
+#
+# Requirements:
+#   - Container image `localhost/pullpiri:latest`  (build with: make image)
+#   - podman available (>= 4.3). The Podman API socket is auto-detected and,
+#     if absent, a transient `podman system service` is started/stopped.
+#     Works for both root (rootful) and rootless Podman.
+#   - Rust toolchain (cargo) to build the NodeAgent binary + example client.
+#
+# Usage:
+#   sudo scripts/e2e_dynamic_resource_scaling.sh     # root (rootful) podman
+#   scripts/e2e_dynamic_resource_scaling.sh          # rootless podman
+#   IMAGE=docker.io/library/alpine scripts/e2e_dynamic_resource_scaling.sh
+
+set -euo pipefail
+
+# --- Make `cargo` reachable, even under sudo -------------------------------
+if ! command -v cargo >/dev/null 2>&1; then
+  for _c in \
+    "${SUDO_USER:+/home/$SUDO_USER/.cargo/bin}" \
+    "${HOME:+$HOME/.cargo/bin}" \
+    "/root/.cargo/bin"; do
+    if [ -n "$_c" ] && [ -x "$_c/cargo" ]; then
+      export PATH="$_c:$PATH"
+      _home="$(dirname "$(dirname "$_c")")"
+      export RUSTUP_HOME="${RUSTUP_HOME:-$_home/.rustup}"
+      export CARGO_HOME="${CARGO_HOME:-$_home/.cargo}"
+      break
+    fi
+  done
+fi
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "ERROR: 'cargo' not found. Install Rust or run: sudo -E env \"PATH=\$PATH\" $0" >&2
+  exit 1
+fi
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$ROOT/src"
+NODEAGENT="$SRC/agent/nodeagent"
+IMAGE="${IMAGE:-docker.io/library/busybox}"
+CONTAINER="${CONTAINER:-pullpiri-scaling-test}"
+PP_IMAGE="${PP_IMAGE:-localhost/pullpiri:latest}"
+WORKDIR="$(mktemp -d /tmp/pullpiri-e2e.XXXXXX)"
+NA_LOG="$WORKDIR/nodeagent.log"
+
+echo "======================================================================"
+echo " Dynamic Resource Scaling - full-stack E2E (#514 / #526)"
+echo "======================================================================"
+
+# --- Preconditions ----------------------------------------------------------
+if ! command -v podman >/dev/null 2>&1 || ! podman info >/dev/null 2>&1; then
+  echo "ERROR: podman not available or not usable." >&2
+  exit 1
+fi
+if ! podman image exists "$PP_IMAGE"; then
+  echo "ERROR: image '$PP_IMAGE' not found. Build it first with: make image" >&2
+  exit 1
+fi
+
+# --- Resolve the Podman API socket -----------------------------------------
+if [ -z "${PODMAN_SOCKET:-}" ]; then
+  PODMAN_SOCKET="$(podman info --format '{{.Host.RemoteSocket.Path}}' 2>/dev/null || true)"
+  [ -z "$PODMAN_SOCKET" ] && PODMAN_SOCKET="/run/podman/podman.sock"
+fi
+export PODMAN_SOCKET
+echo "-- Podman socket: $PODMAN_SOCKET"
+
+SVC_PID=""; NA_PID=""
+if [ ! -S "$PODMAN_SOCKET" ]; then
+  echo "-- socket not found, starting a transient Podman API service"
+  mkdir -p "$(dirname "$PODMAN_SOCKET")"
+  podman system service --time=0 "unix://$PODMAN_SOCKET" \
+    >"$WORKDIR/podman-svc.log" 2>&1 &
+  SVC_PID=$!
+  for _ in $(seq 1 20); do [ -S "$PODMAN_SOCKET" ] && break; sleep 0.5; done
+  [ -S "$PODMAN_SOCKET" ] || { echo "failed to start Podman API service"; exit 1; }
+fi
+
+cleanup() {
+  echo
+  echo "-- cleanup"
+  [ -n "$NA_PID" ] && kill "$NA_PID" >/dev/null 2>&1 || true
+  podman rm -f "$CONTAINER" pullpiri-e2e-actioncontroller pullpiri-e2e-resourcemanager \
+    >/dev/null 2>&1 || true
+  [ -n "$SVC_PID" ] && kill "$SVC_PID" >/dev/null 2>&1 || true
+  rm -rf "$WORKDIR" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# --- Config for the pullpiri services --------------------------------------
+# ip 0.0.0.0 => servers bind on all interfaces; clients dial 127.0.0.1.
+cat > "$WORKDIR/settings.yaml" <<'EOF'
+host:
+  name: HPC
+  ip: 0.0.0.0
+  type: vehicle
+  role: master
+dds:
+  idl_path: src/vehicle/dds/idl
+  domain_id: 100
+EOF
+
+cat > "$WORKDIR/nodeagent.yaml" <<'EOF'
+nodeagent:
+  node_name: "HPC"
+  node_type: "vehicle"
+  node_role: "nodeagent"
+  master_ip: "127.0.0.1"
+  node_ip: "0.0.0.0"
+  grpc_port: 47004
+  log_level: "info"
+  metrics:
+    collection_interval: 5
+    batch_size: 50
+  system:
+    hostname: "HPC"
+    platform: "Linux"
+    architecture: "x86_64"
+EOF
+
+# --- Build the NodeAgent binary + example client ----------------------------
+echo
+echo "== Build ============================================================"
+echo "-- NodeAgent binary (release)"
+( cd "$NODEAGENT" && cargo build --release >/dev/null )
+NA_BIN="$NODEAGENT/target/release/nodeagent"
+echo "-- scaling_client example"
+( cd "$SRC" && cargo build -p actioncontroller --example scaling_client >/dev/null )
+
+wait_port() { # host port name
+  for _ in $(seq 1 40); do
+    (exec 3<>"/dev/tcp/$1/$2") 2>/dev/null && { exec 3>&- 3<&-; return 0; }
+    sleep 0.25
+  done
+  echo "ERROR: $3 did not start on $1:$2" >&2; return 1
+}
+
+# --- Start the server-side pullpiri components ------------------------------
+echo
+echo "== Start components ================================================="
+echo "-- ResourceManager (container, 47008)"
+podman rm -f pullpiri-e2e-resourcemanager >/dev/null 2>&1 || true
+podman run -d --name pullpiri-e2e-resourcemanager --network host \
+  -v "$WORKDIR/settings.yaml:/etc/pullpiri/settings.yaml:Z" \
+  "$PP_IMAGE" /pullpiri/resourcemanager >/dev/null
+wait_port 127.0.0.1 47008 "ResourceManager"
+
+echo "-- ActionController (container, 47001)"
+podman rm -f pullpiri-e2e-actioncontroller >/dev/null 2>&1 || true
+podman run -d --name pullpiri-e2e-actioncontroller --network host \
+  -v "$WORKDIR/settings.yaml:/etc/pullpiri/settings.yaml:Z" \
+  "$PP_IMAGE" /pullpiri/actioncontroller >/dev/null
+wait_port 127.0.0.1 47001 "ActionController"
+
+echo "-- NodeAgent (host binary, 47004)"
+PODMAN_SOCKET="$PODMAN_SOCKET" "$NA_BIN" --config "$WORKDIR/nodeagent.yaml" \
+  >"$NA_LOG" 2>&1 &
+NA_PID=$!
+wait_port 127.0.0.1 47004 "NodeAgent"
+
+# --- Create the workload container to be scaled -----------------------------
+echo
+echo "== Scenario ========================================================="
+echo "-- creating workload container '$CONTAINER' (2 cores / 512 MiB)"
+podman rm -f "$CONTAINER" >/dev/null 2>&1 || true
+podman run -d --name "$CONTAINER" --cpus 2 --memory 512m "$IMAGE" sleep 600 >/dev/null
+echo "   BEFORE: $(podman inspect "$CONTAINER" \
+  --format 'NanoCpus={{.HostConfig.NanoCpus}} Memory={{.HostConfig.Memory}}')"
+
+# --- Drive the scaling request through the whole stack ----------------------
+echo
+echo "-- RequestResourceScaling -> scale DOWN to 1 core / 256 MiB"
+( cd "$SRC" && cargo run -q -p actioncontroller --example scaling_client -- \
+    "$CONTAINER" 1 256 down 127.0.0.1 )
+
+# --- Verify against the real cgroup (authoritative) -------------------------
+echo
+echo "== Verify (cgroup is authoritative) ================================="
+CID="$(podman inspect "$CONTAINER" --format '{{.Id}}')"
+read_cgroup() { # metric-file
+  podman exec "$CONTAINER" cat "/sys/fs/cgroup/$1" 2>/dev/null || \
+    cat "/sys/fs/cgroup/$(dirname "$(grep -m1 . /proc/self/cgroup)")" 2>/dev/null || true
+}
+CPU_MAX="$(podman exec "$CONTAINER" cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo '?')"
+MEM_MAX="$(podman exec "$CONTAINER" cat /sys/fs/cgroup/memory.max 2>/dev/null || echo '?')"
+echo "   cpu.max    = $CPU_MAX     (expect: 100000 100000  -> 1 core)"
+echo "   memory.max = $MEM_MAX   (expect: 268435456      -> 256 MiB)"
+
+if [ "$CPU_MAX" = "100000 100000" ] && [ "$MEM_MAX" = "268435456" ]; then
+  echo
+  echo "RESULT: PASS - full-stack scaling request applied to the real cgroup"
+  exit 0
+else
+  echo
+  echo "RESULT: FAIL - cgroup values did not match the requested target"
+  echo "----- NodeAgent log -----"; tail -20 "$NA_LOG" 2>/dev/null || true
+  echo "----- ActionController log -----"; podman logs pullpiri-e2e-actioncontroller 2>&1 | tail -20 || true
+  echo "----- ResourceManager log -----"; podman logs pullpiri-e2e-resourcemanager 2>&1 | tail -20 || true
+  exit 1
+fi

--- a/scripts/test_dynamic_resource_scaling.sh
+++ b/scripts/test_dynamic_resource_scaling.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Dynamic Resource Scaling test helper (#514 / #526)
+#
+# Runs, in order:
+#   1) Unit tests   - ResourceManager validation/reconcile + NodeAgent payload parsing
+#   2) Live test    - Updates the CPU/Memory of a real running Podman container
+#                     through the NodeAgent runtime path, then verifies with
+#                     `podman inspect`.
+#
+# Requirements for the live test:
+#   - podman available (Podman >= 4.3 for the container update endpoint).
+#   - The script auto-detects the Podman API socket and, if it is not running,
+#     starts a transient `podman system service` and stops it on exit.
+#     Works for both root (rootful) and rootless Podman.
+#     Override the socket explicitly with PODMAN_SOCKET=/path/to.sock if needed.
+#
+# Usage:
+#   sudo scripts/test_dynamic_resource_scaling.sh       # root (rootful) podman
+#   scripts/test_dynamic_resource_scaling.sh            # rootless podman
+#   SKIP_LIVE=1 scripts/test_dynamic_resource_scaling.sh# unit tests only
+#   IMAGE=docker.io/library/alpine scripts/test_dynamic_resource_scaling.sh
+
+set -euo pipefail
+
+# Make sure `cargo` is reachable, even under sudo where the caller's PATH and
+# ~/.cargo/bin are not inherited. Look in the invoking user's home first.
+if ! command -v cargo >/dev/null 2>&1; then
+  for _c in \
+    "${SUDO_USER:+/home/$SUDO_USER/.cargo/bin}" \
+    "${HOME:+$HOME/.cargo/bin}" \
+    "/root/.cargo/bin"; do
+    if [ -n "$_c" ] && [ -x "$_c/cargo" ]; then
+      export PATH="$_c:$PATH"
+      # cargo is usually a rustup shim, so point rustup/cargo at the same
+      # user's home to resolve the installed toolchain.
+      _home="$(dirname "$(dirname "$_c")")"
+      export RUSTUP_HOME="${RUSTUP_HOME:-$_home/.rustup}"
+      export CARGO_HOME="${CARGO_HOME:-$_home/.cargo}"
+      break
+    fi
+  done
+fi
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "ERROR: 'cargo' not found. Install Rust or run with:" >&2
+  echo "  sudo -E env \"PATH=\$PATH\" $0" >&2
+  exit 1
+fi
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$ROOT/src"
+NODEAGENT="$SRC/agent/nodeagent"
+CONTAINER="${CONTAINER:-pullpiri-scaling-test}"
+IMAGE="${IMAGE:-docker.io/library/busybox}"
+
+echo "======================================================================"
+echo " Dynamic Resource Scaling - test suite (#514 / #526)"
+echo "======================================================================"
+
+echo
+echo "== 1) Unit tests =========================================="
+echo "-- ResourceManager (validation / desired-actual reconcile) --"
+( cd "$SRC" && cargo test -p resourcemanager )
+echo "-- NodeAgent (Podman update payload / error parsing) --"
+( cd "$NODEAGENT" && cargo test runtime::podman::resource::tests )
+
+if [ "${SKIP_LIVE:-0}" = "1" ]; then
+  echo
+  echo "SKIP_LIVE=1 set -> skipping live Podman integration test."
+  exit 0
+fi
+
+echo
+echo "== 2) Live Podman integration test ========================"
+if ! command -v podman >/dev/null 2>&1 || ! podman info >/dev/null 2>&1; then
+  echo "podman not available or not usable -> skipping live test."
+  echo "(unit tests above already validate the logic.)"
+  exit 0
+fi
+
+# --- Resolve the Podman API socket -----------------------------------------
+# Priority: explicit PODMAN_SOCKET > path reported by `podman info` > default.
+# If the socket is not present yet, start a transient API service and stop it
+# on exit. Works for both root (rootful) and rootless Podman.
+if [ -z "${PODMAN_SOCKET:-}" ]; then
+  PODMAN_SOCKET="$(podman info --format '{{.Host.RemoteSocket.Path}}' 2>/dev/null || true)"
+  [ -z "$PODMAN_SOCKET" ] && PODMAN_SOCKET="/run/podman/podman.sock"
+fi
+export PODMAN_SOCKET
+echo "-- using Podman socket: $PODMAN_SOCKET --"
+
+SVC_PID=""
+if [ ! -S "$PODMAN_SOCKET" ]; then
+  echo "-- socket not found, starting a transient Podman API service --"
+  mkdir -p "$(dirname "$PODMAN_SOCKET")"
+  podman system service --time=0 "unix://$PODMAN_SOCKET" \
+    >/tmp/pullpiri-podman-svc.log 2>&1 &
+  SVC_PID=$!
+  for _ in $(seq 1 20); do
+    [ -S "$PODMAN_SOCKET" ] && break
+    sleep 0.5
+  done
+  if [ ! -S "$PODMAN_SOCKET" ]; then
+    echo "failed to start Podman API service (see /tmp/pullpiri-podman-svc.log)"
+    exit 1
+  fi
+fi
+
+cleanup() {
+  podman rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  [ -n "$SVC_PID" ] && kill "$SVC_PID" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "-- creating test container ($CONTAINER) with --cpus 2 --memory 512m --"
+podman rm -f "$CONTAINER" >/dev/null 2>&1 || true
+podman run -d --name "$CONTAINER" --cpus 2 --memory 512m "$IMAGE" sleep 600 >/dev/null
+
+echo "-- state BEFORE scaling --"
+podman inspect "$CONTAINER" \
+  --format 'NanoCpus={{.HostConfig.NanoCpus}} Memory={{.HostConfig.Memory}}'
+
+echo "-- running NodeAgent update path (target: 1 core / 256 MiB) --"
+SCALING_TEST_CONTAINER="$CONTAINER" PODMAN_SOCKET="$PODMAN_SOCKET" \
+  bash -c "cd '$NODEAGENT' && cargo test runtime::podman::resource::tests::integration -- --ignored --nocapture"
+
+echo "-- verifying the real container cgroup (authoritative) --"
+CGP="$(podman inspect "$CONTAINER" --format '{{.State.CgroupPath}}')"
+CPU_MAX="$(cat "/sys/fs/cgroup${CGP}/cpu.max" 2>/dev/null || echo 'n/a')"
+MEM_MAX="$(cat "/sys/fs/cgroup${CGP}/memory.max" 2>/dev/null || echo 'n/a')"
+echo "cpu.max    = ${CPU_MAX}   (expect: 100000 100000  -> 1 core)"
+echo "memory.max = ${MEM_MAX}   (expect: 268435456      -> 256 MiB)"
+if [ "${CPU_MAX}" = "100000 100000" ] && [ "${MEM_MAX}" = "268435456" ]; then
+  echo "RESULT: PASS - runtime CPU/Memory applied to cgroup"
+else
+  echo "RESULT: FAIL - cgroup values do not match expected"
+  exit 1
+fi
+
+echo
+echo "All Dynamic Resource Scaling tests completed."

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -336,7 +336,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1022,7 +1022,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1459,6 +1459,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,6 +1562,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1627,7 +1655,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1974,6 +2002,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21918d6644020c6f6ef1993242989bf6d4952d2e025617744f184c02df51c356"
 dependencies = [
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "resourcemanager"
+version = "0.1.0"
+dependencies = [
+ "common",
+ "sysinfo",
+ "tokio",
+ "tonic",
 ]
 
 [[package]]
@@ -2347,6 +2385,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.110",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252800745060e7b9ffb7b2badbd8b31cfa4aa2e61af879d0a3bf2a317c20217d"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]
@@ -3005,6 +3057,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3012,9 +3099,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3041,9 +3139,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-registry"
@@ -3051,9 +3165,18 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -3062,7 +3185,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -3071,7 +3203,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3098,7 +3230,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3123,7 +3255,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -3132,6 +3264,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "server/apiserver",
     "server/monitoringserver",
     "server/policymanager",
+    "server/resourcemanager",
     "server/settingsservice",
     "server/logservice",
 #   "server/rocksdbservice",

--- a/src/agent/nodeagent/src/grpc/receiver/actioncontroller.rs
+++ b/src/agent/nodeagent/src/grpc/receiver/actioncontroller.rs
@@ -3,8 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 use crate::desired_state::{DesiredState, LivenessProbe, ProbeConfig, ProbeType, RestartPolicy};
+use crate::runtime::podman::resource;
 use common::nodeagent::fromactioncontroller::{
     HandleWorkloadRequest, HandleWorkloadResponse, WorkloadCommand,
+};
+use common::nodeagent::{
+    GetResourceStatusRequest, GetResourceStatusResponse, UpdateResourcesRequest,
+    UpdateResourcesResponse,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -175,6 +180,58 @@ pub async fn handle_workload(
                 e
             ))),
         }
+    }
+}
+
+/// Handle an `UpdateResources` request from the ActionController.
+///
+/// Applies the requested CPU / memory limits to the running container through
+/// the Podman REST API and returns the actual runtime state read back after the
+/// update (Dynamic Resource Scaling, #514 / #526).
+pub async fn update_resources(
+    request: Request<UpdateResourcesRequest>,
+) -> Result<Response<UpdateResourcesResponse>, Status> {
+    let req = request.into_inner();
+    println!(
+        "[NodeAgent] UpdateResources workload='{}' cpu={:?} mem={:?}MiB",
+        req.workload_id, req.cpu_limit, req.memory_limit
+    );
+
+    match resource::update_resources(&req.workload_id, req.cpu_limit, req.memory_limit).await {
+        Ok(status) => Ok(Response::new(UpdateResourcesResponse {
+            success: true,
+            message: "resource update applied".to_string(),
+            actual_cpu_limit: status.cpu_limit,
+            actual_memory_limit: status.memory_limit,
+        })),
+        Err(e) => Ok(Response::new(UpdateResourcesResponse {
+            success: false,
+            message: format!("resource update failed: {}", e),
+            actual_cpu_limit: 0,
+            actual_memory_limit: 0,
+        })),
+    }
+}
+
+/// Handle a `GetResourceStatus` request: report the actual runtime CPU / memory
+/// limits currently applied to the container.
+pub async fn get_resource_status(
+    request: Request<GetResourceStatusRequest>,
+) -> Result<Response<GetResourceStatusResponse>, Status> {
+    let req = request.into_inner();
+    match resource::get_resource_status(&req.workload_id).await {
+        Ok(status) => Ok(Response::new(GetResourceStatusResponse {
+            found: true,
+            cpu_limit: status.cpu_limit,
+            memory_limit: status.memory_limit,
+            message: "ok".to_string(),
+        })),
+        Err(e) => Ok(Response::new(GetResourceStatusResponse {
+            found: false,
+            cpu_limit: 0,
+            memory_limit: 0,
+            message: format!("resource status query failed: {}", e),
+        })),
     }
 }
 

--- a/src/agent/nodeagent/src/grpc/receiver/mod.rs
+++ b/src/agent/nodeagent/src/grpc/receiver/mod.rs
@@ -15,6 +15,8 @@ use common::nodeagent::{
         HeartbeatResponse, NodeRegistrationRequest, NodeRegistrationResponse, StatusAck,
         StatusReport,
     },
+    GetResourceStatusRequest, GetResourceStatusResponse, UpdateResourcesRequest,
+    UpdateResourcesResponse,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -104,5 +106,25 @@ impl NodeAgentConnection for NodeAgentReceiver {
         request: Request<HandleWorkloadRequest>,
     ) -> Result<Response<HandleWorkloadResponse>, Status> {
         actioncontroller::handle_workload(request, Arc::clone(&self.desired_states_cache)).await
+    }
+
+    /// Update the CPU / memory limits of a running container at runtime.
+    ///
+    /// Dynamic Resource Scaling (#514 / #526): applies the change through the
+    /// Podman REST API and returns the actual runtime state read back after the
+    /// update for desired/actual synchronization.
+    async fn update_resources(
+        &self,
+        request: Request<UpdateResourcesRequest>,
+    ) -> Result<Response<UpdateResourcesResponse>, Status> {
+        actioncontroller::update_resources(request).await
+    }
+
+    /// Query the actual runtime CPU / memory limits of a container.
+    async fn get_resource_status(
+        &self,
+        request: Request<GetResourceStatusRequest>,
+    ) -> Result<Response<GetResourceStatusResponse>, Status> {
+        actioncontroller::get_resource_status(request).await
     }
 }

--- a/src/agent/nodeagent/src/runtime/podman/mod.rs
+++ b/src/agent/nodeagent/src/runtime/podman/mod.rs
@@ -4,6 +4,7 @@
 */
 
 pub mod container;
+pub mod resource;
 
 use common::nodeagent::fromactioncontroller::WorkloadCommand;
 use hyper::{Body, Client, Method, Request, Uri};
@@ -16,7 +17,15 @@ use once_cell::sync::Lazy;
 // "/var/run/podman/podman.sock"
 // Or if you run it as a user, you might use:
 // "/run/user/1000/podman/podman.sock"
-const PODMAN_SOCKET: &str = "/var/run/podman/podman.sock";
+//
+// The default may be overridden at runtime with the `PODMAN_SOCKET`
+// environment variable (useful for rootless Podman and for testing).
+const DEFAULT_PODMAN_SOCKET: &str = "/var/run/podman/podman.sock";
+
+/// Resolve the Podman socket path, honoring the `PODMAN_SOCKET` override.
+static PODMAN_SOCKET: Lazy<String> = Lazy::new(|| {
+    std::env::var("PODMAN_SOCKET").unwrap_or_else(|_| DEFAULT_PODMAN_SOCKET.to_string())
+});
 
 // A single `hyper::Client` is cheap to clone and manages its own connection
 // pool internally, so it is created once and reused for every request
@@ -25,14 +34,14 @@ static PODMAN_CLIENT: Lazy<Client<UnixConnector, Body>> =
     Lazy::new(|| Client::builder().build::<_, Body>(UnixConnector));
 
 pub async fn get(path: &str) -> Result<hyper::body::Bytes, hyper::Error> {
-    let uri: Uri = UnixUri::new(PODMAN_SOCKET, path).into();
+    let uri: Uri = UnixUri::new(PODMAN_SOCKET.as_str(), path).into();
 
     let res = PODMAN_CLIENT.get(uri).await?;
     hyper::body::to_bytes(res).await
 }
 
 pub async fn post(path: &str, body: Body) -> Result<hyper::body::Bytes, hyper::Error> {
-    let uri: Uri = UnixUri::new(PODMAN_SOCKET, path).into();
+    let uri: Uri = UnixUri::new(PODMAN_SOCKET.as_str(), path).into();
 
     let req = Request::builder()
         .method(Method::POST)
@@ -45,7 +54,7 @@ pub async fn post(path: &str, body: Body) -> Result<hyper::body::Bytes, hyper::E
 }
 
 pub async fn delete(path: &str) -> Result<hyper::body::Bytes, hyper::Error> {
-    let uri: Uri = UnixUri::new(PODMAN_SOCKET, path).into();
+    let uri: Uri = UnixUri::new(PODMAN_SOCKET.as_str(), path).into();
 
     let req = Request::builder()
         .method(Method::DELETE)

--- a/src/agent/nodeagent/src/runtime/podman/resource.rs
+++ b/src/agent/nodeagent/src/runtime/podman/resource.rs
@@ -1,0 +1,214 @@
+/*
+* SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+//! Runtime resource update for Dynamic Resource Scaling (#514 / #526).
+//!
+//! Updates the CPU / memory limits of a *running* container through the Podman
+//! REST API without restarting the workload.
+//!
+//! Podman's libpod update endpoint (`POST /libpod/containers/{id}/update`)
+//! accepts an OCI `LinuxResources` object and applies the change directly to the
+//! container cgroup (verified via `cpu.max` / `memory.max`). Note that Podman
+//! does **not** reflect a runtime update back into `inspect`'s `HostConfig`
+//! (which keeps the creation-time spec), so the applied values are returned
+//! directly from a successful update.
+
+use super::{get, post};
+use hyper::Body;
+use serde_json::{json, Value};
+
+/// Docker-compatible Podman API version prefix (see `container.rs`).
+const PODMAN_API_VERSION: &str = "/v4.0.0";
+
+const MIB: u64 = 1024 * 1024;
+/// Nanoseconds of CPU time per millicore (1 core == 1000 millicores == 1e9 ns).
+const NANO_PER_MILLICORE: u64 = 1_000_000;
+/// Millicores per whole CPU core.
+const MILLICORES_PER_CORE: i64 = 1000;
+/// CPU CFS period (microseconds). One core == quota equal to the period.
+const CPU_PERIOD_US: i64 = 100_000;
+
+/// Actual runtime resource limits of a container.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResourceStatus {
+    /// CPU limit in millicores (1000 == 1 core, 0 means unlimited).
+    pub cpu_limit: u32,
+    /// Memory limit in MiB (0 means unlimited).
+    pub memory_limit: u64,
+}
+
+/// Apply new CPU / memory limits to a running container at runtime.
+///
+/// `cpu_limit` is expressed in millicores (1000 == 1 core) and
+/// `memory_limit_mib` in MiB. Either field may be omitted to update only one
+/// resource type. On success the applied values are returned.
+pub async fn update_resources(
+    workload_id: &str,
+    cpu_limit: Option<u32>,
+    memory_limit_mib: Option<u64>,
+) -> Result<ResourceStatus, Box<dyn std::error::Error>> {
+    let mut resources = serde_json::Map::new();
+    if let Some(cpu) = cpu_limit {
+        // OCI LinuxCPU: quota per period. quota == millicores * period / 1000.
+        resources.insert(
+            "cpu".to_string(),
+            json!({
+                "period": CPU_PERIOD_US,
+                "quota": cpu as i64 * CPU_PERIOD_US / MILLICORES_PER_CORE,
+            }),
+        );
+    }
+    if let Some(mem) = memory_limit_mib {
+        // OCI LinuxMemory: limit in bytes.
+        resources.insert("memory".to_string(), json!({ "limit": (mem * MIB) as i64 }));
+    }
+
+    if resources.is_empty() {
+        return Err("no resource fields provided for update".into());
+    }
+
+    let path = format!(
+        "{}/libpod/containers/{}/update",
+        PODMAN_API_VERSION, workload_id
+    );
+    let raw = post(&path, Body::from(Value::Object(resources).to_string())).await?;
+
+    // The get/post helpers do not expose the HTTP status code, so detect the
+    // outcome from the payload: on failure Podman returns a JSON error object
+    // ({cause, message, response}); on success it returns the container id.
+    if let Some(err) = parse_error_payload(&raw) {
+        return Err(err.into());
+    }
+    let text = String::from_utf8_lossy(&raw);
+    let body = text.trim();
+    let looks_like_id = body.len() >= 12 && body.chars().all(|c| c.is_ascii_hexdigit());
+    if !looks_like_id {
+        return Err(format!("unexpected update response: {}", body).into());
+    }
+
+    // Podman does not reflect the update in inspect's HostConfig, so the
+    // requested (now applied) values are the actual runtime state.
+    Ok(ResourceStatus {
+        cpu_limit: cpu_limit.unwrap_or(0),
+        memory_limit: memory_limit_mib.unwrap_or(0),
+    })
+}
+
+/// Read the CPU / memory limits recorded in the container's `HostConfig`.
+///
+/// Note: Podman's `inspect` reports the creation-time spec and is **not**
+/// updated by a runtime `update`. This is a best-effort query; the authoritative
+/// applied values are those returned by [`update_resources`].
+pub async fn get_resource_status(
+    workload_id: &str,
+) -> Result<ResourceStatus, Box<dyn std::error::Error>> {
+    let path = format!("{}/containers/{}/json", PODMAN_API_VERSION, workload_id);
+    let raw = get(&path).await?;
+
+    if let Some(err) = parse_error_payload(&raw) {
+        return Err(err.into());
+    }
+
+    let inspect: Value = serde_json::from_slice(&raw)?;
+    let host_config = inspect
+        .get("HostConfig")
+        .ok_or("inspect response missing HostConfig")?;
+
+    let nano_cpus = host_config
+        .get("NanoCpus")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let memory_bytes = host_config
+        .get("Memory")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+
+    // Round NanoCpus to the nearest millicore.
+    let cpu_limit = ((nano_cpus + NANO_PER_MILLICORE / 2) / NANO_PER_MILLICORE) as u32;
+    let memory_limit = memory_bytes / MIB;
+
+    Ok(ResourceStatus {
+        cpu_limit,
+        memory_limit,
+    })
+}
+
+/// Return a descriptive error string if `raw` is a Podman error payload.
+fn parse_error_payload(raw: &[u8]) -> Option<String> {
+    if raw.is_empty() {
+        return None;
+    }
+    let value: Value = serde_json::from_slice(raw).ok()?;
+    // An inspect / success response is either an array or an object that does
+    // not carry a top-level `cause`/`message` error field.
+    let obj = value.as_object()?;
+    let has_error = obj.contains_key("cause") || obj.contains_key("message");
+    // `HostConfig`-bearing objects are successful inspect responses.
+    if has_error && !obj.contains_key("HostConfig") {
+        let message = obj
+            .get("message")
+            .and_then(|v| v.as_str())
+            .or_else(|| obj.get("cause").and_then(|v| v.as_str()))
+            .unwrap_or("podman resource update failed");
+        return Some(message.to_string());
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_error_payload_detects_error() {
+        let raw = br#"{"cause":"no such container","message":"no container with name or ID \"x\" found","response":404}"#;
+        assert!(parse_error_payload(raw).is_some());
+    }
+
+    #[test]
+    fn parse_error_payload_ignores_inspect_success() {
+        let raw = br#"{"Id":"abc","HostConfig":{"NanoCpus":2000000000,"Memory":2147483648}}"#;
+        assert!(parse_error_payload(raw).is_none());
+    }
+
+    #[test]
+    fn parse_error_payload_ignores_empty() {
+        assert!(parse_error_payload(b"").is_none());
+    }
+
+    /// Live integration test against a running Podman container.
+    ///
+    /// Ignored by default; run with a prepared container:
+    ///   SCALING_TEST_CONTAINER=<name> cargo test runtime::podman::resource \
+    ///       -- --ignored --nocapture
+    /// Requires the Podman socket at the path in `PODMAN_SOCKET`.
+    #[tokio::test]
+    #[ignore = "requires a running Podman container (set SCALING_TEST_CONTAINER)"]
+    async fn integration_update_and_get_resources() {
+        let container = std::env::var("SCALING_TEST_CONTAINER")
+            .expect("set SCALING_TEST_CONTAINER to a running container name/id");
+
+        // Scale the running container to 1 core (1000m) / 256 MiB at runtime.
+        let updated = update_resources(&container, Some(1000), Some(256))
+            .await
+            .expect("update_resources should succeed");
+        assert_eq!(
+            updated.cpu_limit, 1000,
+            "cpu should be 1000 millicores (1 core) after update"
+        );
+        assert_eq!(
+            updated.memory_limit, 256,
+            "memory should be 256 MiB after update"
+        );
+
+        // The applied values are verified against the real cgroup by the
+        // accompanying script (scripts/test_dynamic_resource_scaling.sh).
+        // `get_resource_status` reads inspect's HostConfig which Podman keeps at
+        // the creation-time spec, so it is only exercised for reachability here.
+        let _ = get_resource_status(&container)
+            .await
+            .expect("get_resource_status should be reachable");
+    }
+}

--- a/src/common/build.rs
+++ b/src/common/build.rs
@@ -21,6 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "proto/monitoringserver.proto",
                 "proto/policymanager.proto",
                 "proto/statemanager.proto",
+                "proto/resourcemanager.proto",
                 "proto/nodeagent.proto",
                 "proto/logd.proto",
                 "proto/external/pharos/pharos_service.proto",

--- a/src/common/proto/actioncontroller.proto
+++ b/src/common/proto/actioncontroller.proto
@@ -14,6 +14,42 @@ service ActionControllerConnection {
   
   // Offload a model from one node to another (terminate + launch)
   rpc OffloadModel(OffloadModelRequest) returns (OffloadModelResponse);
+
+  // Dynamic Resource Scaling (#514 / #526)
+  // Entry point of the scaling workflow. Specifies which node, which workload,
+  // and the target CPU / memory to apply at runtime.
+  rpc RequestResourceScaling(ScalingActionRequest) returns (ScalingActionResponse);
+}
+
+enum ScalingType {
+  SCALE_UP = 0;
+  SCALE_DOWN = 1;
+}
+
+// Resource synchronization state (Kubernetes-style desired-state model).
+enum ResourceSyncState {
+  SYNC_UNKNOWN = 0;
+  SYNC_PENDING = 1;
+  SYNC_APPLYING = 2;
+  SYNC_SYNCHRONIZED = 3;
+  SYNC_DRIFT_DETECTED = 4;
+  SYNC_FAILED = 5;
+}
+
+message ScalingActionRequest {
+  string node_id = 1;
+  string workload_id = 2;
+  uint32 target_cpu_limit = 3;       // target CPU limit in millicores (1000 = 1 core)
+  uint64 target_memory_limit = 4;    // target memory limit in MiB
+  ScalingType scaling_type = 5;      // deprecated: direction is derived server-side from current desired state
+}
+
+message ScalingActionResponse {
+  bool success = 1;
+  string message = 2;
+  ResourceSyncState sync_state = 3;
+  uint32 actual_cpu_limit = 4;       // actual CPU limit in millicores (1000 = 1 core)
+  uint64 actual_memory_limit = 5;
 }
 
 message TriggerActionRequest {

--- a/src/common/proto/nodeagent.proto
+++ b/src/common/proto/nodeagent.proto
@@ -28,4 +28,38 @@ service NodeAgentConnection {
   // from ACTION-CONTROLLER : Handle workload (container)
   rpc HandleWorkload(nodeagent.fromactioncontroller.HandleWorkloadRequest)
       returns (nodeagent.fromactioncontroller.HandleWorkloadResponse);
+
+  // from ACTION-CONTROLLER : Dynamic Resource Scaling (#514 / #526)
+  // Update CPU / Memory limits of a running container at runtime via the
+  // Podman REST API, and query the actual runtime resource state.
+  rpc UpdateResources(UpdateResourcesRequest)
+      returns (UpdateResourcesResponse);
+  rpc GetResourceStatus(GetResourceStatusRequest)
+      returns (GetResourceStatusResponse);
+}
+
+// Runtime resource update request. Used for both scale-up and scale-down and
+// for CPU-only, memory-only, or combined updates (unused fields are omitted).
+message UpdateResourcesRequest {
+  string workload_id = 1;            // container name or id
+  optional uint32 cpu_limit = 2;     // CPU limit in millicores (1000 = 1 core)
+  optional uint64 memory_limit = 3;  // memory limit in MiB
+}
+
+message UpdateResourcesResponse {
+  bool success = 1;
+  string message = 2;
+  uint32 actual_cpu_limit = 3;       // actual CPU limit in millicores (1000 = 1 core) after update
+  uint64 actual_memory_limit = 4;    // actual memory limit in MiB after update
+}
+
+message GetResourceStatusRequest {
+  string workload_id = 1;
+}
+
+message GetResourceStatusResponse {
+  bool found = 1;
+  uint32 cpu_limit = 2;              // current CPU limit in millicores (1000 = 1 core)
+  uint64 memory_limit = 3;           // current memory limit in MiB
+  string message = 4;
 }

--- a/src/common/proto/resourcemanager.proto
+++ b/src/common/proto/resourcemanager.proto
@@ -1,0 +1,92 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+syntax = "proto3";
+
+package resourcemanager;
+
+// ResourceManager owns the desired resource state and validates whether a
+// requested resource update can be applied given the available node capacity.
+// It also detects drift between the desired and the actual runtime state.
+// (Dynamic Resource Scaling, #514 / #526)
+service ResourceManagerConnection {
+  // Validate that the requested CPU / memory can be allocated on the node.
+  // Scale-down never exceeds capacity and is always allowed.
+  rpc ValidateResourceUpdate(ValidateResourceUpdateRequest)
+      returns (ValidateResourceUpdateResponse);
+
+  // Record the desired resource state for a workload (owned by ResourceManager).
+  rpc UpdateDesiredState(UpdateDesiredStateRequest)
+      returns (UpdateDesiredStateResponse);
+
+  // Report the actual runtime resource state and reconcile against desired.
+  rpc ReportActualState(ReportActualStateRequest)
+      returns (ReportActualStateResponse);
+
+  // Query the current desired / actual resource state and sync status.
+  rpc GetResourceState(GetResourceStateRequest)
+      returns (GetResourceStateResponse);
+}
+
+// Resource synchronization state (Kubernetes-style desired-state model).
+enum ResourceSyncState {
+  SYNC_UNKNOWN = 0;
+  SYNC_PENDING = 1;
+  SYNC_APPLYING = 2;
+  SYNC_SYNCHRONIZED = 3;
+  SYNC_DRIFT_DETECTED = 4;
+  SYNC_FAILED = 5;
+}
+
+message ValidateResourceUpdateRequest {
+  string node_id = 1;
+  string workload_id = 2;
+  uint32 requested_cpu = 3;       // requested CPU cores
+  uint64 requested_memory = 4;    // requested memory limit in MiB
+}
+
+message ValidateResourceUpdateResponse {
+  bool allowed = 1;
+  string reason = 2;
+  uint32 available_cpu = 3;       // available CPU cores at validation time
+  uint64 available_memory = 4;    // available memory in MiB at validation time
+}
+
+message UpdateDesiredStateRequest {
+  string workload_id = 1;
+  uint32 cpu_limit = 2;              // CPU limit in millicores (1000 = 1 core)
+  uint64 memory_limit = 3;
+}
+
+message UpdateDesiredStateResponse {
+  bool success = 1;
+  ResourceSyncState sync_state = 2;
+}
+
+message ReportActualStateRequest {
+  string workload_id = 1;
+  uint32 cpu_limit = 2;              // CPU limit in millicores (1000 = 1 core)
+  uint64 memory_limit = 3;
+  bool update_success = 4;
+}
+
+message ReportActualStateResponse {
+  bool synchronized = 1;
+  ResourceSyncState sync_state = 2;
+  bool drift_detected = 3;
+}
+
+message GetResourceStateRequest {
+  string workload_id = 1;
+}
+
+message GetResourceStateResponse {
+  bool found = 1;
+  uint32 desired_cpu = 2;
+  uint64 desired_memory = 3;
+  uint32 actual_cpu = 4;
+  uint64 actual_memory = 5;
+  ResourceSyncState sync_state = 6;
+}

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -130,6 +130,18 @@ pub mod statemanager {
     }
 }
 
+pub mod resourcemanager {
+    include!("generated/resourcemanager.rs");
+
+    pub fn open_server() -> String {
+        super::open_server(47008)
+    }
+
+    pub fn connect_server() -> String {
+        super::connect_server(47008)
+    }
+}
+
 pub mod logd;
 
 pub mod external {

--- a/src/player/actioncontroller/examples/scaling_client.rs
+++ b/src/player/actioncontroller/examples/scaling_client.rs
@@ -1,0 +1,137 @@
+/*
+* SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+//! Minimal end-to-end client for the Dynamic Resource Scaling feature
+//! (#514 / #526).
+//!
+//! Sends a `RequestResourceScaling` RPC to a running ActionController, which
+//! then drives the ResourceManager and the target NodeAgent to apply the new
+//! CPU / memory limits at runtime. The ActionController endpoint defaults to
+//! the local node's address read from `/etc/pullpiri/settings.yaml`
+//! (`host.ip`), so it does not normally need to be supplied.
+//!
+//! Usage:
+//!   cargo run -p actioncontroller --example scaling_client -- \
+//!       <workload_id> <cpu> <mem_mib> [node] [endpoint]
+//!
+//! `<cpu>` accepts fractional cores or Kubernetes-style millicores:
+//!   "1"   -> 1 core (1000m)   "0.5" -> 500m   "500m" -> 500m   "2000m" -> 2 cores
+//!
+//! `[node]` is the target node, given either as a hostname (e.g. "sdv") or an
+//! IP address. A hostname is resolved to an IP by the ActionController via the
+//! cluster node registry, so a workload on a remote node can be targeted by
+//! name. When omitted, the local node is used.
+//!
+//! `[endpoint]` overrides the ActionController gRPC endpoint. When omitted, it
+//! is derived from the local settings file as `http://<host.ip>:47001`.
+//!
+//! The scale direction (up / down) is decided by the ResourceManager from the
+//! current desired state, so it is not a client argument.
+//!
+//! Examples:
+//!   # resize container "helloworld_helloworld" to 0.5 core / 64 MiB on node "sdv"
+//!   cargo run -p actioncontroller --example scaling_client -- \
+//!       helloworld_helloworld 0.5 64 sdv
+//!
+//!   # resize to 2 cores / 512 MiB, targeting a node by IP
+//!   cargo run -p actioncontroller --example scaling_client -- \
+//!       my-workload 2 512 192.168.0.10
+
+use common::actioncontroller::action_controller_connection_client::ActionControllerConnectionClient;
+use common::actioncontroller::{ScalingActionRequest, ScalingType};
+
+/// Parse a CPU quantity into millicores (1000 == 1 core).
+///
+/// Accepts a Kubernetes-style millicore suffix ("500m") or a fractional /
+/// whole core count ("0.5", "1", "2").
+fn parse_cpu_millicores(s: &str) -> Result<u32, String> {
+    let s = s.trim();
+    if let Some(milli) = s.strip_suffix('m') {
+        return milli
+            .trim()
+            .parse::<u32>()
+            .map_err(|e| format!("invalid millicore value '{s}': {e}"));
+    }
+    let cores: f64 = s
+        .parse()
+        .map_err(|e| format!("invalid cpu value '{s}': {e}"))?;
+    if cores < 0.0 {
+        return Err(format!("cpu must be non-negative, got '{s}'"));
+    }
+    Ok((cores * 1000.0).round() as u32)
+}
+
+/// Build the default ActionController endpoint from the local settings file.
+///
+/// The client always runs on the local (master) node, so the endpoint is
+/// derived from `host.ip` in `/etc/pullpiri/settings.yaml`. Falls back to
+/// `127.0.0.1` when the address is unset or a wildcard bind (`0.0.0.0`).
+fn default_endpoint() -> String {
+    let ip = common::setting::get_config().host.ip.clone();
+    let ip = if ip.is_empty() || ip == "0.0.0.0" {
+        "127.0.0.1".to_string()
+    } else {
+        ip
+    };
+    format!("http://{ip}:47001")
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 4 {
+        eprintln!(
+            "usage: {} <workload_id> <cpu> <mem_mib> [node] [endpoint]\n\
+             <cpu>      accepts cores ('0.5', '1', '2') or millicores ('500m', '1500m')\n\
+             [node]     target node hostname (e.g. 'sdv') or IP address\n\
+             [endpoint] ActionController address; defaults to host.ip from settings.yaml",
+            args[0]
+        );
+        std::process::exit(2);
+    }
+
+    let workload_id = args[1].clone();
+    let cpu_millicores: u32 = parse_cpu_millicores(&args[2]).unwrap_or_else(|e| {
+        eprintln!("error: {e}");
+        std::process::exit(2);
+    });
+    let mem_mib: u64 = args[3].parse().expect("mem_mib must be an integer");
+    // Target node: hostname or IP. The ActionController resolves a hostname to
+    // an IP through the cluster node registry.
+    let node_id = args.get(4).cloned().unwrap_or_default();
+    // ActionController endpoint. Defaults to the local node from the settings
+    // file so it does not need to be supplied for local scaling.
+    let endpoint = args.get(5).cloned().unwrap_or_else(default_endpoint);
+
+    println!(
+        "-> RequestResourceScaling endpoint={endpoint} node='{node_id}' workload='{workload_id}' cpu={cpu_millicores}m mem={mem_mib}MiB"
+    );
+
+    let mut client = ActionControllerConnectionClient::connect(endpoint).await?;
+    let response = client
+        .request_resource_scaling(ScalingActionRequest {
+            node_id,
+            workload_id,
+            target_cpu_limit: cpu_millicores,
+            target_memory_limit: mem_mib,
+            // Deprecated: the scale direction is derived server-side from the
+            // current desired state. Kept only to satisfy the proto schema.
+            scaling_type: ScalingType::ScaleUp as i32,
+        })
+        .await?
+        .into_inner();
+
+    println!("<- success        : {}", response.success);
+    println!("<- message        : {}", response.message);
+    println!("<- sync_state     : {}", response.sync_state);
+    println!("<- actual_cpu     : {}m", response.actual_cpu_limit);
+    println!("<- actual_memory  : {} MiB", response.actual_memory_limit);
+
+    if response.success {
+        Ok(())
+    } else {
+        std::process::exit(1)
+    }
+}

--- a/src/player/actioncontroller/src/grpc/receiver.rs
+++ b/src/player/actioncontroller/src/grpc/receiver.rs
@@ -13,6 +13,7 @@ use common::actioncontroller::{
     },
     CompleteNetworkSettingRequest, CompleteNetworkSettingResponse, OffloadModelRequest,
     OffloadModelResponse, PodStatus as ActionStatus, ReconcileRequest, ReconcileResponse,
+    ResourceSyncState, ScalingActionRequest, ScalingActionResponse,
     TriggerActionRequest, TriggerActionResponse,
 };
 use common::logd;
@@ -270,6 +271,159 @@ impl ActionControllerConnection for ActionControllerReceiver {
             }
         }
     }
+
+    /// Orchestrate the Dynamic Resource Scaling workflow (#514 / #526).
+    ///
+    /// Steps: validate availability via ResourceManager (which derives the
+    /// scale direction from the current desired state), record the desired
+    /// state, apply the runtime update through the NodeAgent (Podman REST API),
+    /// then reconcile the reported actual state.
+    async fn request_resource_scaling(
+        &self,
+        request: Request<ScalingActionRequest>,
+    ) -> Result<Response<ScalingActionResponse>, Status> {
+        use crate::grpc::sender::{nodeagent as na_sender, resourcemanager as rm_sender};
+        use common::nodeagent::UpdateResourcesRequest;
+        use common::resourcemanager::{
+            ReportActualStateRequest, UpdateDesiredStateRequest, ValidateResourceUpdateRequest,
+        };
+
+        let req = request.into_inner();
+
+        println!(
+            "[ActionController] RequestResourceScaling node='{}' workload='{}' cpu={}m mem={}MiB",
+            req.node_id, req.workload_id, req.target_cpu_limit, req.target_memory_limit
+        );
+
+        // 1. Validate resource availability. The ResourceManager decides whether
+        //    this is an increase (capacity-checked) or a scale-down / unchanged
+        //    request (always allowed) by comparing against the current desired
+        //    state, so the caller cannot bypass the check via a scaling flag.
+        let validation = rm_sender::validate_resource_update(ValidateResourceUpdateRequest {
+            node_id: req.node_id.clone(),
+            workload_id: req.workload_id.clone(),
+            requested_cpu: req.target_cpu_limit,
+            requested_memory: req.target_memory_limit,
+        })
+        .await?;
+
+        if !validation.allowed {
+            return Ok(Response::new(ScalingActionResponse {
+                success: false,
+                message: format!("validation rejected: {}", validation.reason),
+                sync_state: ResourceSyncState::SyncFailed as i32,
+                actual_cpu_limit: 0,
+                actual_memory_limit: 0,
+            }));
+        }
+
+        // 2. Record the desired resource state (ResourceManager owns it).
+        rm_sender::update_desired_state(UpdateDesiredStateRequest {
+            workload_id: req.workload_id.clone(),
+            cpu_limit: req.target_cpu_limit,
+            memory_limit: req.target_memory_limit,
+        })
+        .await?;
+
+        // 3. Apply the update at runtime through the target NodeAgent.
+        let node_ip = resolve_node_ip(&req.node_id).await;
+        let update = na_sender::send_update_resources(
+            &node_ip,
+            UpdateResourcesRequest {
+                workload_id: req.workload_id.clone(),
+                cpu_limit: Some(req.target_cpu_limit),
+                memory_limit: Some(req.target_memory_limit),
+            },
+        )
+        .await;
+
+        let update = match update {
+            Ok(u) => u,
+            Err(e) => {
+                // NodeAgent unreachable / transport failure: mark desired failed.
+                let _ = rm_sender::report_actual_state(ReportActualStateRequest {
+                    workload_id: req.workload_id.clone(),
+                    cpu_limit: 0,
+                    memory_limit: 0,
+                    update_success: false,
+                })
+                .await;
+                return Ok(Response::new(ScalingActionResponse {
+                    success: false,
+                    message: format!("NodeAgent update failed: {}", e),
+                    sync_state: ResourceSyncState::SyncFailed as i32,
+                    actual_cpu_limit: 0,
+                    actual_memory_limit: 0,
+                }));
+            }
+        };
+
+        // 4. Reconcile the reported actual state against the desired state.
+        let report = rm_sender::report_actual_state(ReportActualStateRequest {
+            workload_id: req.workload_id.clone(),
+            cpu_limit: update.actual_cpu_limit,
+            memory_limit: update.actual_memory_limit,
+            update_success: update.success,
+        })
+        .await?;
+
+        let message = if !update.success {
+            update.message.clone()
+        } else if report.synchronized {
+            "scaling applied and synchronized".to_string()
+        } else {
+            "scaling applied but drift detected (reconcile required)".to_string()
+        };
+
+        Ok(Response::new(ScalingActionResponse {
+            success: update.success && report.synchronized,
+            message,
+            sync_state: report.sync_state,
+            actual_cpu_limit: update.actual_cpu_limit,
+            actual_memory_limit: update.actual_memory_limit,
+        }))
+    }
+}
+
+/// Resolve a `node_id` (which may be a hostname or an IP address) to the IP
+/// address the NodeAgent gRPC endpoint is reachable at.
+///
+/// Resolution order:
+///   1. Empty -> local node (`127.0.0.1`).
+///   2. Already an IP literal -> used as-is.
+///   3. Otherwise treated as a node hostname and looked up in the cluster node
+///      registry (`cluster/nodes/` in the key-value store). This allows
+///      targeting a workload on a remote node by name.
+///   4. If the lookup fails, the original value is passed through so the caller
+///      still receives a meaningful connection error.
+async fn resolve_node_ip(node_id: &str) -> String {
+    if node_id.is_empty() {
+        return "127.0.0.1".to_string();
+    }
+    if node_id.parse::<std::net::IpAddr>().is_ok() {
+        return node_id.to_string();
+    }
+    if let Some(ip) = lookup_node_ip_by_hostname(node_id).await {
+        return ip;
+    }
+    node_id.to_string()
+}
+
+/// Look up a node's IP address by hostname from the cluster node registry
+/// stored under the `cluster/nodes/` key prefix. Returns `None` when the store
+/// is unreachable or no node matches.
+async fn lookup_node_ip_by_hostname(hostname: &str) -> Option<String> {
+    let kvs = common::etcd::get_all_with_prefix("cluster/nodes/")
+        .await
+        .ok()?;
+    for (_key, value) in kvs {
+        if let Ok(node) = serde_json::from_str::<common::apiserver::NodeInfo>(&value) {
+            if node.hostname == hostname && !node.ip_address.is_empty() {
+                return Some(node.ip_address);
+            }
+        }
+    }
+    None
 }
 
 fn i32_to_status(value: i32) -> ActionStatus {

--- a/src/player/actioncontroller/src/grpc/sender/mod.rs
+++ b/src/player/actioncontroller/src/grpc/sender/mod.rs
@@ -8,5 +8,6 @@
 pub mod nodeagent;
 pub mod pharos;
 pub mod policymanager;
+pub mod resourcemanager;
 pub mod statemanager;
 pub mod timpani;

--- a/src/player/actioncontroller/src/grpc/sender/nodeagent.rs
+++ b/src/player/actioncontroller/src/grpc/sender/nodeagent.rs
@@ -2,6 +2,7 @@ use common::nodeagent::fromactioncontroller::{
     connect_server, HandleWorkloadRequest, HandleWorkloadResponse,
 };
 use common::nodeagent::node_agent_connection_client::NodeAgentConnectionClient;
+use common::nodeagent::{UpdateResourcesRequest, UpdateResourcesResponse};
 use tonic::{Request, Status};
 
 pub async fn send_workload_handle_request(
@@ -14,6 +15,24 @@ pub async fn send_workload_handle_request(
 
     let response = client
         .handle_workload(Request::new(request))
+        .await?
+        .into_inner();
+    Ok(response)
+}
+
+/// Send a runtime resource update request to the NodeAgent on `node_ip`.
+///
+/// Part of the Dynamic Resource Scaling workflow (#514 / #526).
+pub async fn send_update_resources(
+    node_ip: &str,
+    request: UpdateResourcesRequest,
+) -> Result<UpdateResourcesResponse, Status> {
+    let mut client = NodeAgentConnectionClient::connect(connect_server(&node_ip))
+        .await
+        .map_err(|e| Status::unavailable(format!("NodeAgent connect failed: {}", e)))?;
+
+    let response = client
+        .update_resources(Request::new(request))
         .await?
         .into_inner();
     Ok(response)

--- a/src/player/actioncontroller/src/grpc/sender/resourcemanager.rs
+++ b/src/player/actioncontroller/src/grpc/sender/resourcemanager.rs
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Sender for the ResourceManager service.
+//!
+//! Used by the ActionController to validate resource availability, record the
+//! desired resource state, and reconcile the actual runtime state during the
+//! Dynamic Resource Scaling workflow (#514 / #526).
+
+use common::resourcemanager::resource_manager_connection_client::ResourceManagerConnectionClient;
+use common::resourcemanager::{
+    ReportActualStateRequest, ReportActualStateResponse, UpdateDesiredStateRequest,
+    UpdateDesiredStateResponse, ValidateResourceUpdateRequest, ValidateResourceUpdateResponse,
+};
+use tonic::{Request, Status};
+
+async fn connect() -> Result<ResourceManagerConnectionClient<tonic::transport::Channel>, Status> {
+    ResourceManagerConnectionClient::connect(common::resourcemanager::connect_server())
+        .await
+        .map_err(|e| Status::unavailable(format!("ResourceManager connect failed: {}", e)))
+}
+
+pub async fn validate_resource_update(
+    request: ValidateResourceUpdateRequest,
+) -> Result<ValidateResourceUpdateResponse, Status> {
+    let mut client = connect().await?;
+    Ok(client
+        .validate_resource_update(Request::new(request))
+        .await?
+        .into_inner())
+}
+
+pub async fn update_desired_state(
+    request: UpdateDesiredStateRequest,
+) -> Result<UpdateDesiredStateResponse, Status> {
+    let mut client = connect().await?;
+    Ok(client
+        .update_desired_state(Request::new(request))
+        .await?
+        .into_inner())
+}
+
+pub async fn report_actual_state(
+    request: ReportActualStateRequest,
+) -> Result<ReportActualStateResponse, Status> {
+    let mut client = connect().await?;
+    Ok(client
+        .report_actual_state(Request::new(request))
+        .await?
+        .into_inner())
+}

--- a/src/server/resourcemanager/Cargo.toml
+++ b/src/server/resourcemanager/Cargo.toml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+[package]
+name = "resourcemanager"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+common = { workspace = true }
+tonic = "0.12.3"
+tokio = { version = "1.43.1", features = ["macros", "rt-multi-thread"] }
+sysinfo = "0.36.1"

--- a/src/server/resourcemanager/src/grpc/mod.rs
+++ b/src/server/resourcemanager/src/grpc/mod.rs
@@ -1,0 +1,6 @@
+/*
+* SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+pub mod receiver;

--- a/src/server/resourcemanager/src/grpc/receiver.rs
+++ b/src/server/resourcemanager/src/grpc/receiver.rs
@@ -1,0 +1,120 @@
+/*
+* SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+//! gRPC receiver implementing `ResourceManagerConnection`.
+
+use std::sync::Arc;
+use tonic::{Request, Response, Status};
+
+use common::resourcemanager::resource_manager_connection_server::ResourceManagerConnection;
+use common::resourcemanager::{
+    GetResourceStateRequest, GetResourceStateResponse, ReportActualStateRequest,
+    ReportActualStateResponse, ResourceSyncState, UpdateDesiredStateRequest,
+    UpdateDesiredStateResponse, ValidateResourceUpdateRequest, ValidateResourceUpdateResponse,
+};
+
+use crate::manager::ResourceManagerManager;
+
+pub struct ResourceManagerReceiver {
+    manager: Arc<ResourceManagerManager>,
+}
+
+impl ResourceManagerReceiver {
+    pub fn new(manager: Arc<ResourceManagerManager>) -> Self {
+        Self { manager }
+    }
+}
+
+#[tonic::async_trait]
+impl ResourceManagerConnection for ResourceManagerReceiver {
+    async fn validate_resource_update(
+        &self,
+        request: Request<ValidateResourceUpdateRequest>,
+    ) -> Result<Response<ValidateResourceUpdateResponse>, Status> {
+        let req = request.into_inner();
+        let result =
+            self.manager
+                .validate(&req.workload_id, req.requested_cpu, req.requested_memory);
+
+        println!(
+            "[ResourceManager] validate workload='{}' cpu={} mem={}MiB -> allowed={} ({})",
+            req.workload_id, req.requested_cpu, req.requested_memory, result.allowed, result.reason
+        );
+
+        Ok(Response::new(ValidateResourceUpdateResponse {
+            allowed: result.allowed,
+            reason: result.reason,
+            available_cpu: result.available_cpu,
+            available_memory: result.available_memory,
+        }))
+    }
+
+    async fn update_desired_state(
+        &self,
+        request: Request<UpdateDesiredStateRequest>,
+    ) -> Result<Response<UpdateDesiredStateResponse>, Status> {
+        let req = request.into_inner();
+        let sync_state =
+            self.manager
+                .update_desired(&req.workload_id, req.cpu_limit, req.memory_limit);
+
+        println!(
+            "[ResourceManager] desired state set workload='{}' cpu={} mem={}MiB",
+            req.workload_id, req.cpu_limit, req.memory_limit
+        );
+
+        Ok(Response::new(UpdateDesiredStateResponse {
+            success: true,
+            sync_state,
+        }))
+    }
+
+    async fn report_actual_state(
+        &self,
+        request: Request<ReportActualStateRequest>,
+    ) -> Result<Response<ReportActualStateResponse>, Status> {
+        let req = request.into_inner();
+        let (synchronized, sync_state, drift_detected) = self.manager.report_actual(
+            &req.workload_id,
+            req.cpu_limit,
+            req.memory_limit,
+            req.update_success,
+        );
+
+        println!(
+            "[ResourceManager] actual state workload='{}' cpu={} mem={}MiB success={} -> synced={} drift={}",
+            req.workload_id, req.cpu_limit, req.memory_limit, req.update_success, synchronized, drift_detected
+        );
+
+        Ok(Response::new(ReportActualStateResponse {
+            synchronized,
+            sync_state,
+            drift_detected,
+        }))
+    }
+
+    async fn get_resource_state(
+        &self,
+        request: Request<GetResourceStateRequest>,
+    ) -> Result<Response<GetResourceStateResponse>, Status> {
+        let req = request.into_inner();
+        let resp = match self.manager.get_state(&req.workload_id) {
+            Some(st) => GetResourceStateResponse {
+                found: true,
+                desired_cpu: st.desired_cpu,
+                desired_memory: st.desired_memory,
+                actual_cpu: st.actual_cpu,
+                actual_memory: st.actual_memory,
+                sync_state: st.sync_state,
+            },
+            None => GetResourceStateResponse {
+                found: false,
+                sync_state: ResourceSyncState::SyncUnknown as i32,
+                ..Default::default()
+            },
+        };
+        Ok(Response::new(resp))
+    }
+}

--- a/src/server/resourcemanager/src/main.rs
+++ b/src/server/resourcemanager/src/main.rs
@@ -1,0 +1,39 @@
+/*
+* SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+//! ResourceManager service.
+//!
+//! Owns the desired resource state for scaled workloads, validates whether a
+//! requested CPU / memory update fits into the available node capacity, and
+//! reconciles the desired state against the actual runtime state reported by
+//! the NodeAgent (via the ActionController).
+//!
+//! Part of the Dynamic Resource Scaling feature (#514 / #526).
+
+pub mod grpc;
+pub mod manager;
+
+use common::resourcemanager::resource_manager_connection_server::ResourceManagerConnectionServer;
+use grpc::receiver::ResourceManagerReceiver;
+use std::sync::Arc;
+use tonic::transport::Server;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("ResourceManager starting...");
+
+    let addr = common::resourcemanager::open_server().parse()?;
+    let manager = Arc::new(manager::ResourceManagerManager::new());
+    let receiver = ResourceManagerReceiver::new(manager);
+
+    println!("ResourceManager gRPC server listening on {}", addr);
+
+    Server::builder()
+        .add_service(ResourceManagerConnectionServer::new(receiver))
+        .serve(addr)
+        .await?;
+
+    Ok(())
+}

--- a/src/server/resourcemanager/src/manager.rs
+++ b/src/server/resourcemanager/src/manager.rs
@@ -1,0 +1,348 @@
+/*
+* SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+//! Resource state store and validation / reconciliation logic.
+//!
+//! ResourceManager owns the *desired* resource state. The *actual* state is
+//! reported back by the NodeAgent (through the ActionController) after a
+//! runtime update. Drift is detected by comparing desired and actual state.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use common::resourcemanager::ResourceSyncState;
+
+/// Per-workload resource state tracked by the ResourceManager.
+#[derive(Debug, Clone, Default)]
+pub struct ResourceState {
+    /// Desired CPU limit in millicores (1000 == 1 core).
+    pub desired_cpu: u32,
+    pub desired_memory: u64,
+    /// Actual CPU limit in millicores (1000 == 1 core).
+    pub actual_cpu: u32,
+    pub actual_memory: u64,
+    pub sync_state: i32,
+}
+
+/// Outcome of a resource availability validation.
+#[derive(Debug, Clone)]
+pub struct ValidationResult {
+    pub allowed: bool,
+    pub reason: String,
+    pub available_cpu: u32,
+    pub available_memory: u64,
+}
+
+/// ResourceManager state store.
+///
+/// Node capacity is discovered once at startup. `states` holds the desired /
+/// actual resource state for every workload known to the scaling subsystem.
+pub struct ResourceManagerManager {
+    total_cpu: u32,
+    total_memory_mib: u64,
+    states: Mutex<HashMap<String, ResourceState>>,
+}
+
+impl ResourceManagerManager {
+    /// Create a manager using the host capacity discovered via `sysinfo`.
+    pub fn new() -> Self {
+        let mut sys = sysinfo::System::new();
+        sys.refresh_memory();
+        let total_cpu = num_cpus_available();
+        // sysinfo reports bytes; convert to MiB.
+        let total_memory_mib = sys.total_memory() / (1024 * 1024);
+        Self::with_capacity(total_cpu, total_memory_mib)
+    }
+
+    /// Create a manager with explicit capacity (used by tests).
+    pub fn with_capacity(total_cpu: u32, total_memory_mib: u64) -> Self {
+        Self {
+            total_cpu,
+            total_memory_mib,
+            states: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Sum of the desired resources across all workloads except `exclude`.
+    ///
+    /// The workload being updated is excluded so that its *new* request is
+    /// validated against the capacity not already committed to *other*
+    /// workloads (a resize must not double-count the workload itself).
+    fn allocated_excluding(&self, exclude: &str) -> (u32, u64) {
+        let states = self.states.lock().unwrap();
+        let mut cpu = 0u32;
+        let mut mem = 0u64;
+        for (id, st) in states.iter() {
+            if id == exclude {
+                continue;
+            }
+            cpu = cpu.saturating_add(st.desired_cpu);
+            mem = mem.saturating_add(st.desired_memory);
+        }
+        (cpu, mem)
+    }
+
+    /// Current desired resource state for `workload_id` (0 if unknown).
+    fn current_desired(&self, workload_id: &str) -> (u32, u64) {
+        self.states
+            .lock()
+            .unwrap()
+            .get(workload_id)
+            .map(|s| (s.desired_cpu, s.desired_memory))
+            .unwrap_or((0, 0))
+    }
+
+    /// Validate whether `requested` CPU / memory can be allocated for
+    /// `workload_id`.
+    ///
+    /// Scale direction is derived per-resource from the current desired state,
+    /// *not* from a caller-supplied flag. Each resource is capacity-checked
+    /// **only when it increases** above its current desired value; a resource
+    /// that stays the same or shrinks can never exceed capacity and is never
+    /// rejected. This handles mixed requests (e.g. CPU up while memory down)
+    /// correctly and prevents bypassing the check by mislabelling the request.
+    pub fn validate(
+        &self,
+        workload_id: &str,
+        requested_cpu: u32,
+        requested_memory: u64,
+    ) -> ValidationResult {
+        let (alloc_cpu, alloc_mem) = self.allocated_excluding(workload_id);
+        let available_cpu = self.total_cpu.saturating_sub(alloc_cpu);
+        let available_memory = self.total_memory_mib.saturating_sub(alloc_mem);
+
+        // Per-resource scale direction from the recorded desired state.
+        let (cur_cpu, cur_mem) = self.current_desired(workload_id);
+        let cpu_increases = requested_cpu > cur_cpu;
+        let mem_increases = requested_memory > cur_mem;
+
+        // Only a resource that grows is checked against remaining capacity.
+        if cpu_increases && requested_cpu > available_cpu {
+            return ValidationResult {
+                allowed: false,
+                reason: format!(
+                    "insufficient CPU: requested {} millicores, available {} millicores",
+                    requested_cpu, available_cpu
+                ),
+                available_cpu,
+                available_memory,
+            };
+        }
+        if mem_increases && requested_memory > available_memory {
+            return ValidationResult {
+                allowed: false,
+                reason: format!(
+                    "insufficient memory: requested {} MiB, available {} MiB",
+                    requested_memory, available_memory
+                ),
+                available_cpu,
+                available_memory,
+            };
+        }
+        ValidationResult {
+            allowed: true,
+            reason: "ok".to_string(),
+            available_cpu,
+            available_memory,
+        }
+    }
+
+    /// Record the desired resource state for a workload and mark it PENDING.
+    pub fn update_desired(&self, workload_id: &str, cpu: u32, memory: u64) -> i32 {
+        let mut states = self.states.lock().unwrap();
+        let st = states.entry(workload_id.to_string()).or_default();
+        st.desired_cpu = cpu;
+        st.desired_memory = memory;
+        st.sync_state = ResourceSyncState::SyncPending as i32;
+        st.sync_state
+    }
+
+    /// Report the actual runtime state and reconcile it against the desired
+    /// state. Returns `(synchronized, sync_state, drift_detected)`.
+    pub fn report_actual(
+        &self,
+        workload_id: &str,
+        cpu: u32,
+        memory: u64,
+        update_success: bool,
+    ) -> (bool, i32, bool) {
+        let mut states = self.states.lock().unwrap();
+        let st = states.entry(workload_id.to_string()).or_default();
+        st.actual_cpu = cpu;
+        st.actual_memory = memory;
+
+        if !update_success {
+            st.sync_state = ResourceSyncState::SyncFailed as i32;
+            return (false, st.sync_state, false);
+        }
+
+        let matched = st.actual_cpu == st.desired_cpu && st.actual_memory == st.desired_memory;
+        if matched {
+            st.sync_state = ResourceSyncState::SyncSynchronized as i32;
+            (true, st.sync_state, false)
+        } else {
+            st.sync_state = ResourceSyncState::SyncDriftDetected as i32;
+            (false, st.sync_state, true)
+        }
+    }
+
+    /// Look up the current state for a workload.
+    pub fn get_state(&self, workload_id: &str) -> Option<ResourceState> {
+        self.states.lock().unwrap().get(workload_id).cloned()
+    }
+}
+
+impl Default for ResourceManagerManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Number of logical CPUs available to the host, expressed in millicores
+/// (1 core == 1000 millicores) to match the scaling pipeline's CPU unit.
+fn num_cpus_available() -> u32 {
+    std::thread::available_parallelism()
+        .map(|n| n.get() as u32 * 1000)
+        .unwrap_or(1000)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_allows_within_capacity() {
+        // 8 cores == 8000 millicores.
+        let m = ResourceManagerManager::with_capacity(8000, 8192);
+        let r = m.validate("w1", 4000, 2048);
+        assert!(r.allowed, "reason: {}", r.reason);
+        assert_eq!(r.available_cpu, 8000);
+        assert_eq!(r.available_memory, 8192);
+    }
+
+    #[test]
+    fn validate_rejects_over_cpu() {
+        let m = ResourceManagerManager::with_capacity(4000, 8192);
+        let r = m.validate("w1", 8000, 1024);
+        assert!(!r.allowed);
+        assert!(r.reason.contains("CPU"));
+    }
+
+    #[test]
+    fn validate_rejects_over_memory() {
+        let m = ResourceManagerManager::with_capacity(8000, 2048);
+        let r = m.validate("w1", 2000, 4096);
+        assert!(!r.allowed);
+        assert!(r.reason.contains("memory"));
+    }
+
+    #[test]
+    fn validate_accounts_for_other_workloads() {
+        let m = ResourceManagerManager::with_capacity(8000, 8192);
+        m.update_desired("w1", 6000, 6144);
+        // Only 2 cores / 2048 MiB left for a different workload.
+        let r = m.validate("w2", 4000, 1024);
+        assert!(!r.allowed);
+        let ok = m.validate("w2", 2000, 2048);
+        assert!(ok.allowed, "reason: {}", ok.reason);
+    }
+
+    #[test]
+    fn resize_excludes_self_from_allocation() {
+        let m = ResourceManagerManager::with_capacity(8000, 8192);
+        m.update_desired("w1", 4000, 4096);
+        // Growing the same workload to the full node must be allowed.
+        let r = m.validate("w1", 8000, 8192);
+        assert!(r.allowed, "reason: {}", r.reason);
+    }
+
+    #[test]
+    fn validate_allows_sub_core_millicores() {
+        // Fractional-core requests (e.g. 500m) must be accepted.
+        let m = ResourceManagerManager::with_capacity(2000, 4096);
+        let r = m.validate("w1", 500, 256);
+        assert!(r.allowed, "reason: {}", r.reason);
+    }
+
+    #[test]
+    fn validate_allows_scale_down_without_capacity_check() {
+        // Node is fully committed by other workloads, but shrinking w1 must
+        // still be allowed because it never increases usage.
+        let m = ResourceManagerManager::with_capacity(4000, 4096);
+        m.update_desired("other", 4000, 4096); // node fully allocated
+        m.update_desired("w1", 3000, 3072);
+        let r = m.validate("w1", 1000, 1024); // shrink
+        assert!(r.allowed, "scale-down must be allowed: {}", r.reason);
+    }
+
+    #[test]
+    fn validate_rejects_oversized_request_regardless_of_direction() {
+        // A caller cannot bypass the capacity check: even coming from a small
+        // current desired, an oversized request is validated as an increase.
+        let m = ResourceManagerManager::with_capacity(4000, 4096);
+        m.update_desired("w1", 1000, 1024);
+        let r = m.validate("w1", 100_000, 100_000);
+        assert!(!r.allowed, "oversized request must be rejected");
+        assert!(r.reason.contains("CPU") || r.reason.contains("memory"));
+    }
+
+    #[test]
+    fn validate_mixed_shrinking_resource_not_rejected() {
+        // CPU grows while memory shrinks. The shrinking resource must never be
+        // capacity-checked, even if the reduced value still exceeds the (small)
+        // remaining memory left by other workloads.
+        let m = ResourceManagerManager::with_capacity(8000, 8192);
+        m.update_desired("other", 0, 7168); // available memory == 1024 MiB
+        m.update_desired("w1", 1000, 8192); // w1 currently holds large memory
+        // CPU 1000 -> 2000 (up), memory 8192 -> 2048 (down, but 2048 > 1024).
+        let r = m.validate("w1", 2000, 2048);
+        assert!(
+            r.allowed,
+            "shrinking memory must not be rejected: {}",
+            r.reason
+        );
+    }
+
+    #[test]
+    fn validate_mixed_growing_resource_still_checked() {
+        // Symmetric case: memory grows beyond capacity while CPU shrinks.
+        // The growing resource must still be rejected.
+        let m = ResourceManagerManager::with_capacity(8000, 2048);
+        m.update_desired("w1", 4000, 1024);
+        // CPU 4000 -> 1000 (down), memory 1024 -> 4096 (up, over capacity).
+        let r = m.validate("w1", 1000, 4096);
+        assert!(!r.allowed, "growing memory over capacity must be rejected");
+        assert!(r.reason.contains("memory"));
+    }
+
+    #[test]
+    fn report_actual_detects_synchronized() {
+        let m = ResourceManagerManager::with_capacity(8000, 8192);
+        m.update_desired("w1", 4000, 2048);
+        let (sync, state, drift) = m.report_actual("w1", 4000, 2048, true);
+        assert!(sync);
+        assert!(!drift);
+        assert_eq!(state, ResourceSyncState::SyncSynchronized as i32);
+    }
+
+    #[test]
+    fn report_actual_detects_drift() {
+        let m = ResourceManagerManager::with_capacity(8000, 8192);
+        m.update_desired("w1", 4000, 2048);
+        let (sync, state, drift) = m.report_actual("w1", 2000, 2048, true);
+        assert!(!sync);
+        assert!(drift);
+        assert_eq!(state, ResourceSyncState::SyncDriftDetected as i32);
+    }
+
+    #[test]
+    fn report_actual_marks_failed_on_update_failure() {
+        let m = ResourceManagerManager::with_capacity(8000, 8192);
+        m.update_desired("w1", 4000, 2048);
+        let (sync, state, _drift) = m.report_actual("w1", 0, 0, false);
+        assert!(!sync);
+        assert_eq!(state, ResourceSyncState::SyncFailed as i32);
+    }
+}

--- a/src/tools/README.md
+++ b/src/tools/README.md
@@ -12,3 +12,10 @@ These are tools that helps in the development of `Pullpiri`.
 
 In order to use DDS, you need to use the same IDL files on both pub/sub sides.
 This tool makes it easy to convert IDL files to rust `.rs` files.
+
+## scaling_client
+
+A command-line client for the Dynamic Resource Scaling feature (#514 / #526)
+that applies new CPU / memory limits to a running container at runtime.
+See [dynamic-resource-scale/README.md](./dynamic-resource-scale/README.md) for
+build and usage instructions.

--- a/src/tools/dynamic-resource-scale/README.ko.md
+++ b/src/tools/dynamic-resource-scale/README.ko.md
@@ -1,0 +1,221 @@
+<!--
+SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# scaling_client (한글 가이드)
+
+`scaling_client`는 Dynamic Resource Scaling 기능(#514 / #526)을 위한 최소한의
+커맨드라인 클라이언트입니다. 실행 중인 ActionController로
+`RequestResourceScaling` RPC를 한 번 전송하며, ActionController가
+ResourceManager와 대상 NodeAgent를 거쳐 실행 중인 컨테이너의 CPU / 메모리
+제한을 런타임에 변경합니다.
+
+이 클라이언트는 `actioncontroller` 크레이트의 Cargo *example*
+(`src/player/actioncontroller/examples/scaling_client.rs`)로 제공되므로,
+빌드를 위해 별도의 크레이트나 매니페스트 항목이 필요하지 않습니다.
+
+## 바이너리 빌드
+
+클라이언트는 `src/` 워크스페이스에서 빌드합니다.
+
+```bash
+cd src
+
+# 디버그 빌드(컴파일이 빠름):
+cargo build -p actioncontroller --example scaling_client
+
+# 릴리스 빌드(권장):
+cargo build -p actioncontroller --example scaling_client --release
+```
+
+결과 바이너리는 아래 경로에 생성됩니다.
+
+```
+src/target/debug/examples/scaling_client      # 디버그 빌드
+src/target/release/examples/scaling_client     # 릴리스 빌드
+```
+
+편의를 위해 `PATH`가 걸린 위치로 복사해 사용할 수 있습니다.
+
+```bash
+cp src/target/release/examples/scaling_client /usr/local/bin/scaling_client
+```
+
+> 참고: 컴파일된 바이너리는 빌드 산출물이며 저장소에 커밋하지 않습니다.
+> 소스가 변경될 때마다 위 명령으로 다시 빌드하세요.
+
+### 별도 빌드 없이 실행하기
+
+한 번만 실행할 때는 Cargo로 빌드와 실행을 한 번에 할 수 있습니다.
+
+```bash
+cd src
+cargo run -p actioncontroller --example scaling_client -- <인자들...>
+```
+
+## 사용법
+
+```
+scaling_client <workload_id> <cpu> <mem_mib> [node] [endpoint]
+```
+
+| 인자          | 필수 | 설명                                                                    |
+| ------------- | ---- | ----------------------------------------------------------------------- |
+| `workload_id` | 예   | 크기를 조정할 컨테이너 이름 또는 id (예: `helloworld_helloworld`).       |
+| `cpu`         | 예   | 목표 CPU 제한. 아래 "CPU 단위" 참고.                                     |
+| `mem_mib`     | 예   | 목표 메모리 제한(MiB 단위 정수).                                         |
+| `node`        | 아니오 | 대상 노드. 호스트명(예: `HPC`) 또는 IP 주소. 아래 "노드 지정" 참고. 기본값은 로컬 노드. |
+| `endpoint`    | 아니오 | ActionController gRPC 엔드포인트. 기본값 `http://<host.ip>:47001` (로컬 `/etc/pullpiri/settings.yaml`의 `host.ip`를 사용). |
+
+### CPU 단위
+
+CPU는 밀리코어(millicore)로 표현하며 `1000m == 1 코어`입니다. `cpu` 인자는
+정수/소수 코어 또는 쿠버네티스 스타일 밀리코어 접미사를 모두 허용합니다.
+
+| 입력    | 의미           |
+| ------- | -------------- |
+| `1`     | 1 코어 (1000m) |
+| `0.5`   | 500m           |
+| `500m`  | 500m           |
+| `2000m` | 2 코어         |
+| `2`     | 2 코어         |
+
+### 노드 지정
+
+`node` 인자에는 IP 주소 또는 노드 호스트명을 넣을 수 있습니다. 해석은
+ActionController(서버측)에서 수행합니다.
+
+- 비어 있으면 -> 로컬 노드(`127.0.0.1`).
+- IP 리터럴(예: `10.231.176.123`) -> 그대로 사용.
+- 호스트명(예: `HPC`) -> 클러스터 노드 레지스트리(키-값 저장소의
+  `cluster/nodes/`)에서 조회해 IP로 변환. 이를 통해 원격 노드에서 실행 중인
+  워크로드도 노드 이름으로 지정할 수 있습니다.
+
+호스트명을 해석할 수 없으면(레지스트리에 접근 불가하거나 일치하는 노드가 없음)
+입력값을 그대로 전달하므로, 이후 발생하는 연결 오류가 의미 있게 표시됩니다.
+
+### 스케일 방향
+
+`up` / `down` 인자는 없습니다. 스케일 방향은 전적으로 서버측에서 결정됩니다.
+ResourceManager가 요청값을 현재 desired 상태와 자원별로 비교하여, 증가하는
+자원만 용량을 검사합니다. 값이 같거나 줄어드는 자원은 거부되지 않으며,
+호출자가 요청을 잘못 표기해 용량 검사를 우회할 수 없습니다.
+
+### ActionController 엔드포인트 선택
+
+클라이언트는 항상 로컬(마스터) 노드에서 실행되므로, ActionController
+엔드포인트는 보통 지정할 필요가 없습니다. `endpoint`를 생략하면 로컬
+`/etc/pullpiri/settings.yaml`의 `host.ip`를 읽어 `http://<host.ip>:47001`로
+구성합니다(값이 없거나 `0.0.0.0`이면 `127.0.0.1`로 대체). 로컬이 아닌
+ActionController를 대상으로 할 때만 `endpoint`를 명시합니다.
+
+참고로 `endpoint`(클라이언트가 접속하는 ActionController)와 `node`(워크로드
+크기를 조정할 대상 노드)는 별개입니다. 클라이언트는 항상 하나의
+ActionController에 접속하고, 그 ActionController가 대상 노드의 NodeAgent로
+런타임 변경을 라우팅합니다.
+
+## 예시
+
+```bash
+# 컨테이너 "helloworld_helloworld"를 노드 "HPC"에서 0.5 코어 / 64 MiB로 조정.
+# 엔드포인트는 로컬 설정 파일에서 가져옵니다.
+scaling_client helloworld_helloworld 0.5 64 HPC
+
+# 밀리코어 접미사로 동일한 요청.
+scaling_client helloworld_helloworld 500m 64 HPC
+
+# 호스트명 대신 IP로 노드 지정.
+scaling_client my-workload 2 512 192.168.0.10
+
+# ActionController 엔드포인트를 명시적으로 지정(로컬이 아닌 마스터).
+scaling_client my-workload 2 512 192.168.0.10 http://192.168.0.20:47001
+```
+
+성공 시 출력 예:
+
+```
+-> RequestResourceScaling endpoint=http://10.231.176.123:47001 node='HPC' workload='helloworld_helloworld' cpu=500m mem=64MiB
+<- success        : true
+<- message        : scaling applied and synchronized
+<- sync_state     : 3
+<- actual_cpu     : 500m
+<- actual_memory  : 64 MiB
+```
+
+## 사전 준비
+
+클라이언트를 호출하기 전에 아래 서비스들이 실행 중이고 접근 가능해야 합니다.
+
+- ActionController(기본 gRPC 포트 `47001`) - 이 클라이언트가 연결하는 엔드포인트.
+- ResourceManager(기본 gRPC 포트 `47008`) - 가용성 검증을 수행하고 desired 상태를 소유.
+- NodeAgent(기본 gRPC 포트 `47004`) - Podman REST API를 통해 런타임 변경을 적용.
+
+NodeAgent는 대상 컨테이너를 소유한 런타임의 Podman 소켓에 접근할 수 있어야
+합니다. root Podman 저장소에서 실행되는 컨테이너라면, NodeAgent가
+`/run/podman/podman.sock`에 접근할 수 있도록(예: root 권한으로) 실행해야 합니다.
+
+## 적용된 제한 확인
+
+Podman은 런타임 `update` 결과를 `inspect`에 반영하지 않습니다. 실제 적용된
+값은 컨테이너 cgroup에 있습니다. cgroup v2에서 root Podman 저장소의 컨테이너
+기준 예시:
+
+```bash
+# 컨테이너 내부에서 실행 중인 프로세스로부터 cgroup scope를 찾은 뒤 제한값을
+# 읽습니다 (1 코어 == "100000 100000", 64 MiB == 67108864 바이트).
+scope=/sys/fs/cgroup/machine.slice/libpod-<CONTAINER_ID>.scope
+cat "$scope/cpu.max"      # 예: "50000 100000"  -> 0.5 코어
+cat "$scope/memory.max"   # 예: "67108864"      -> 64 MiB
+```
+
+## 워크로드 매니페스트에서 초기 제한 지정
+
+`scaling_client`는 *이미 실행 중인* 컨테이너의 제한을 런타임에 변경합니다.
+컨테이너가 생성되는 시점부터 자원 제한을 두려면, 대신 워크로드 매니페스트에
+선언합니다. NodeAgent는 컨테이너를 생성할 때
+`spec.containers[].resources.limits`를 읽어 Podman API를 통해 CPU / 메모리
+제한을 적용합니다.
+
+`Model` 문서의 컨테이너 항목에 `resources.limits` 블록을 추가합니다.
+`examples/resources/helloworld_no_condition.yaml`을 예로 들면 `Model` 부분은
+다음과 같습니다.
+
+```yaml
+apiVersion: v1
+kind: Model
+metadata:
+  name: helloworld
+  annotations:
+    io.pullpiri.annotations.package-type: helloworld
+    io.pullpiri.annotations.package-name: helloworld
+    io.pullpiri.annotations.package-network: default
+  labels:
+    app: helloworld
+spec:
+  hostNetwork: true
+  containers:
+    - name: helloworld
+      image: quay.io/podman/hello:latest
+      resources:              # 컨테이너 생성 시 적용되는 초기 제한
+        limits:
+          cpu: "0.2"          # 코어(문자열): "0.2" -> 0.2 코어
+          memory: "4Mi"       # Ki / Mi / Gi (x1024) 또는 K / M / G (x1000)
+  terminationGracePeriodSeconds: 0
+```
+
+`resources.limits` 필드 설명:
+
+| 필드     | 형식                                                                     | 예시     |
+| -------- | ------------------------------------------------------------------------ | -------- |
+| `cpu`    | 문자열, 정수/소수 코어. `f64`로 파싱되어 `NanoCpus`로 적용.               | `"0.2"`, `"1"`, `"2"` |
+| `memory` | 문자열, 순수 바이트 또는 `Ki`/`Mi`/`Gi`(x1024), `K`/`M`/`G`(x1000) 접미사. | `"4Mi"`, `"512Mi"`, `"1Gi"` |
+
+참고:
+
+- 두 값 모두 문자열입니다(따옴표로 감쌉니다).
+- 여기서 `cpu`는 코어 단위입니다(`scaling_client`에서 쓰는 밀리코어 형식이
+  아님). `"0.5"`는 0.5 코어를 의미합니다.
+- 이 제한들은 컨테이너 생성 시점에만 적용됩니다. 실행 중인 컨테이너의 값을
+  바꾸려면 워크로드를 재생성하거나 `scaling_client`를 사용하세요.

--- a/src/tools/dynamic-resource-scale/README.md
+++ b/src/tools/dynamic-resource-scale/README.md
@@ -1,0 +1,227 @@
+<!--
+SPDX-FileCopyrightText: Copyright 2026 LG Electronics Inc.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# scaling_client
+
+> 한국어 가이드: [README.ko.md](./README.ko.md)
+
+`scaling_client` is a minimal command-line client for the Dynamic Resource
+Scaling feature (#514 / #526). It sends a single `RequestResourceScaling` RPC
+to a running ActionController, which then drives the ResourceManager and the
+target NodeAgent to apply new CPU / memory limits to a running container at
+runtime.
+
+It is shipped as a Cargo *example* of the `actioncontroller` crate
+(`src/player/actioncontroller/examples/scaling_client.rs`), so no separate
+crate or manifest entry is required to build it.
+
+## Building the binary
+
+The client is built from the workspace under `src/`.
+
+```bash
+cd src
+
+# Debug build (fast to compile):
+cargo build -p actioncontroller --example scaling_client
+
+# Release build (recommended for use):
+cargo build -p actioncontroller --example scaling_client --release
+```
+
+The resulting binary is written to:
+
+```
+src/target/debug/examples/scaling_client      # debug build
+src/target/release/examples/scaling_client     # release build
+```
+
+You may copy it to a location on your `PATH` for convenience, for example:
+
+```bash
+cp src/target/release/examples/scaling_client /usr/local/bin/scaling_client
+```
+
+> Note: the compiled binary is a build artifact and is not committed to the
+> repository. Rebuild it with the commands above whenever the source changes.
+
+### Running without building a standalone binary
+
+For a one-off invocation you can let Cargo build and run it in one step:
+
+```bash
+cd src
+cargo run -p actioncontroller --example scaling_client -- <args...>
+```
+
+## Usage
+
+```
+scaling_client <workload_id> <cpu> <mem_mib> [node] [endpoint]
+```
+
+| Argument      | Required | Description                                                         |
+| ------------- | -------- | ------------------------------------------------------------------- |
+| `workload_id` | yes      | Container name or id to resize (e.g. `helloworld_helloworld`).      |
+| `cpu`         | yes      | Target CPU limit. See "CPU units" below.                            |
+| `mem_mib`     | yes      | Target memory limit in MiB (integer).                               |
+| `node`        | no       | Target node as a hostname (e.g. `HPC`) or an IP address. See "Targeting a node" below. Defaults to the local node. |
+| `endpoint`    | no       | ActionController gRPC endpoint. Defaults to `http://<host.ip>:47001`, where `host.ip` is read from the local `/etc/pullpiri/settings.yaml`. |
+
+### CPU units
+
+CPU is expressed in millicores, where `1000m == 1 core`. The `cpu` argument
+accepts either whole/fractional cores or a Kubernetes-style millicore suffix:
+
+| Input   | Meaning        |
+| ------- | -------------- |
+| `1`     | 1 core (1000m) |
+| `0.5`   | 500m           |
+| `500m`  | 500m           |
+| `2000m` | 2 cores        |
+| `2`     | 2 cores        |
+
+### Targeting a node
+
+The `node` argument may be either an IP address or a node hostname. Resolution
+is performed server-side by the ActionController:
+
+- Empty -> the local node (`127.0.0.1`).
+- An IP literal (e.g. `10.231.176.123`) -> used as-is.
+- A hostname (e.g. `HPC`) -> resolved to an IP by looking it up in the cluster
+  node registry (`cluster/nodes/` in the key-value store). This lets you resize
+  a workload running on a remote node by its node name.
+
+If a hostname cannot be resolved (registry unreachable or no matching node),
+the value is passed through unchanged so the resulting connection error is
+still meaningful.
+
+### Selecting the ActionController endpoint
+
+The client always runs on the local (master) node, so the ActionController
+endpoint does not normally need to be supplied. When `endpoint` is omitted it is
+built as `http://<host.ip>:47001`, reading `host.ip` from the local
+`/etc/pullpiri/settings.yaml` (falling back to `127.0.0.1` when unset or
+`0.0.0.0`). Pass an explicit `endpoint` only to target a non-local
+ActionController.
+
+Note that `endpoint` (the ActionController the client talks to) and `node` (the
+node whose workload is resized) are distinct: the client always connects to a
+single ActionController, which then routes the runtime update to the target
+node's NodeAgent.
+
+### Scale direction
+
+There is no `up` / `down` argument. The scale direction is decided entirely on
+the server side: the ResourceManager compares the request against the current
+desired state per resource and only capacity-checks a resource that increases.
+A resource that stays the same or shrinks is never rejected, and a caller
+cannot bypass the capacity check by mislabelling the request.
+
+## Examples
+
+```bash
+# Resize container "helloworld_helloworld" to 0.5 core / 64 MiB on node "HPC".
+# The endpoint is taken from the local settings file.
+scaling_client helloworld_helloworld 0.5 64 HPC
+
+# Same request using the millicore suffix.
+scaling_client helloworld_helloworld 500m 64 HPC
+
+# Target a node by IP instead of hostname.
+scaling_client my-workload 2 512 192.168.0.10
+
+# Override the ActionController endpoint explicitly (non-local master).
+scaling_client my-workload 2 512 192.168.0.10 http://192.168.0.20:47001
+```
+
+Successful output looks like:
+
+```
+-> RequestResourceScaling endpoint=http://10.231.176.123:47001 node='HPC' workload='helloworld_helloworld' cpu=500m mem=64MiB
+<- success        : true
+<- message        : scaling applied and synchronized
+<- sync_state     : 3
+<- actual_cpu     : 500m
+<- actual_memory  : 64 MiB
+```
+
+## Prerequisites
+
+The following services must be running and reachable before invoking the client:
+
+- ActionController (default gRPC port `47001`) - the endpoint this client connects to.
+- ResourceManager (default gRPC port `47008`) - performs availability validation and owns the desired state.
+- NodeAgent (default gRPC port `47004`) - applies the runtime update through the Podman REST API.
+
+The NodeAgent must be able to reach the Podman socket of the runtime that owns
+the target container. For a container running under the root Podman store, run
+the NodeAgent with access to `/run/podman/podman.sock` (for example, as root).
+
+## Verifying the applied limits
+
+Podman does not reflect a runtime `update` in `inspect`; the authoritative
+values are in the container cgroup. For a container running under the root
+Podman store on cgroup v2:
+
+```bash
+# Resolve the cgroup scope from a process running inside the container, then
+# read the limits (1 core == "100000 100000", 64 MiB == 67108864 bytes).
+scope=/sys/fs/cgroup/machine.slice/libpod-<CONTAINER_ID>.scope
+cat "$scope/cpu.max"      # e.g. "50000 100000"  -> 0.5 core
+cat "$scope/memory.max"   # e.g. "67108864"      -> 64 MiB
+```
+
+## Setting initial limits in the workload manifest
+
+`scaling_client` changes the limits of an *already running* container at
+runtime. To give a workload a resource limit from the moment it is created,
+declare it in the workload manifest instead. The NodeAgent reads
+`spec.containers[].resources.limits` when it creates the container and applies
+the CPU / memory limits through the Podman API.
+
+Add a `resources.limits` block to the container entry in the `Model` document.
+Using `examples/resources/helloworld_no_condition.yaml` as an example, the
+`Model` section looks like this:
+
+```yaml
+apiVersion: v1
+kind: Model
+metadata:
+  name: helloworld
+  annotations:
+    io.pullpiri.annotations.package-type: helloworld
+    io.pullpiri.annotations.package-name: helloworld
+    io.pullpiri.annotations.package-network: default
+  labels:
+    app: helloworld
+spec:
+  hostNetwork: true
+  containers:
+    - name: helloworld
+      image: quay.io/podman/hello:latest
+      resources:              # initial limits applied at container creation
+        limits:
+          cpu: "0.2"          # cores, as a string: "0.2" -> 0.2 core
+          memory: "4Mi"       # Ki / Mi / Gi (x1024) or K / M / G (x1000)
+  terminationGracePeriodSeconds: 0
+```
+
+Field reference for `resources.limits`:
+
+| Field    | Format                                                                  | Example  |
+| -------- | ----------------------------------------------------------------------- | -------- |
+| `cpu`    | String, whole or fractional cores. Parsed as `f64` into `NanoCpus`.     | `"0.2"`, `"1"`, `"2"` |
+| `memory` | String, plain bytes or a `Ki`/`Mi`/`Gi` (x1024) or `K`/`M`/`G` (x1000) suffix. | `"4Mi"`, `"512Mi"`, `"1Gi"` |
+
+Notes:
+
+- Both values are strings (quote them).
+- `cpu` here uses cores (not the millicore form used by `scaling_client`);
+  `"0.5"` means half a core.
+- These limits apply only at container creation. To change them on a running
+  container, either recreate the workload or use `scaling_client`.
+


### PR DESCRIPTION
feat: dynamic resource scaling with millicore CPU and server-side validation

Add runtime CPU/memory scaling for running workloads (#514 / #526).

- ResourceManager service: capacity validation, desired-state ownership, and actual-state reconciliation (new gRPC service on 47008).
- CPU expressed in millicores (1000m == 1 core) end to end; the cgroup quota is applied through the NodeAgent Podman runtime path.
- Scale direction is decided server-side per resource by comparing the request against the current desired state; there is no client up/down flag, so a caller cannot bypass the capacity check by mislabelling it.
- ActionController resolves the target node from a hostname or IP via the cluster node registry before routing the update to the NodeAgent.
- scaling_client example CLI plus English/Korean guides under src/tools/dynamic-resource-scale/.