### PR TITLE
docs: remove obsolete firewall/SELinux setup steps and fix guide links

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ runtime and systemd.
 
 ## Getting started
 
-Refer to [Getting Started](/doc/docs/getting-started.md).
+Refer to [Getting Started](/doc/guides/getting-started.md).
 
 ## Development
 
-Refer to [Development](/doc/docs/developments.md).
+Refer to [Development](/doc/guides/developments.md).
 
 ## License
 
@@ -66,7 +66,7 @@ For detail, refer to [license-readme](/LICENSES/README.md).
 ## How to Get Involved
 
 To contribute to this project, please review the contribution guidelines and join the conversation.
-- [Contribution guidelines](doc/contribution/guidelines-en.md)
+- [Contribution guidelines](/contribution/guidelines-en.md)
 - [Weekly meeting (Microsoft Teams)](https://teams.microsoft.com/meet/46052781724289?p=v7AILMRZryXY01ApNs)
 
 Meeting minutes and announcements are posted here:

--- a/doc/guides/developments.md
+++ b/doc/guides/developments.md
@@ -12,7 +12,7 @@ This documents contains developments, testings, static analysis informations.
 
 ### Environment Setup
 
-For detail, refer to [installation](/doc/docs/getting-started.md#installation).
+For detail, refer to [installation](/doc/guides/getting-started.md#installation).
 
 ### Build
 
@@ -50,7 +50,7 @@ make image
 make install
 ```
 
-For more details, refer to the [Getting started](/doc/docs/getting-started.md)
+For more details, refer to the [Getting started](/doc/guides/getting-started.md)
 
 ## Static analysis
 
@@ -249,7 +249,7 @@ for etcd (default)
 
 Files for documentation of this project are located in the [doc](/doc/) directory comprising:
 
-- [Getting Started](/doc/docs/getting-started.md): how to run
+- [Getting Started](/doc/guides/getting-started.md): how to run
 - [Examples](/examples/README.md): directory containing all files and guides for performing example
 - (Deprecated) ~~[pullpiri.drawio](/doc/images/pullpiri.drawio):
 file containing all diagrams used for Pullpiri~~

--- a/doc/guides/developments_KO.md
+++ b/doc/guides/developments_KO.md
@@ -12,7 +12,7 @@ SPDX-License-Identifier: Apache-2.0
 
 ### 환경 설정
 
-자세한 내용은 [설치 가이드](/doc/docs/getting-started.md#installation)를 참고하세요.
+자세한 내용은 [설치 가이드](/doc/guides/getting-started.md#installation)를 참고하세요.
 
 ### 빌드
 
@@ -50,7 +50,7 @@ make image
 make install
 ```
 
-자세한 내용은 [시작하기](/doc/docs/getting-started.md)를 참고하세요.
+자세한 내용은 [시작하기](/doc/guides/getting-started.md)를 참고하세요.
 
 ## 정적 분석
 
@@ -247,7 +247,7 @@ etcd (기본값)
 
 이 프로젝트의 문서 파일은 [doc](/doc/) 디렉토리에 위치하며, 다음을 포함합니다:
 
-- [시작하기](/doc/docs/getting-started.md): 실행 방법
+- [시작하기](/doc/guides/getting-started.md): 실행 방법
 - [예제](/examples/README.md): 예제 수행을 위한 모든 파일과 가이드가 포함된 디렉토리
 - (Deprecated) ~~[pullpiri.drawio](/doc/images/pullpiri.drawio):
 Pullpiri에 사용된 모든 다이어그램이 포함된 파일~~

--- a/doc/guides/getting-started.md
+++ b/doc/guides/getting-started.md
@@ -45,13 +45,13 @@ dds:
 ### Pullpiri modules
 
 Pullpiri consists of many modules.
-For each modules, refer to [Structure](/doc/docs/developments.md#structure).  
+For each modules, refer to [Structure](/doc/guides/developments.md#structure).  
 And the [example](/examples/README.md) would be helpful.
 
 ## Limitations
 
 - Multi-node system and the resulting node-selectors have not yet been fully considered.
-- For better operation, recommend operating with `root` user with selinux permissive mode.
+- For better operation, recommend operating with `root` user (required for systemd service registration and access to system paths such as `/etc`, `/opt`).
 - `/etc/containers/systemd` folder is used for pullpiri systemd service files. This cannot be changed.
 - Because it is still an early version, it may sometimes take a lot of time to start/stop/update the container.
 - There may be other issues as well.
@@ -60,16 +60,11 @@ And the [example](/examples/README.md) would be helpful.
 
 ### Before installation
 
-need some packages, disable firewall, permissive selinux
+need some packages.
 
 ```bash
-# disable firewall
-systemctl stop firewalld
-systemctl disable firewalld
 # install package
 dnf install git-all make gcc -y
-# permissive selinux
-setenforce 0
 ```
 
 For modifying configuration, see [configuration](#pullpiri-configuration).

--- a/doc/guides/getting-started_KO.md
+++ b/doc/guides/getting-started_KO.md
@@ -45,13 +45,13 @@ dds:
 ### Pullpiri 모듈
 
 Pullpiri는 여러 모듈로 구성되어 있습니다.
-각 모듈에 대한 자세한 내용은 [Structure](/doc/docs/developments.md#structure)를 참고하세요.  
+각 모듈에 대한 자세한 내용은 [Structure](/doc/guides/developments.md#structure)를 참고하세요.  
 또한 [예제](/examples/README.md)가 도움이 될 것입니다.
 
 ## 제한 사항
 
 - 멀티 노드 시스템 및 그에 따른 노드 셀렉터는 아직 완전히 고려되지 않았습니다.
-- 원활한 운영을 위해 selinux permissive 모드의 `root` 사용자로 운영하는 것을 권장합니다.
+- 원활한 운영을 위해 `root` 사용자로 운영하는 것을 권장합니다 (systemd 서비스 등록 및 `/etc`, `/opt` 등 시스템 경로 접근에 필요).
 - `/etc/containers/systemd` 폴더는 Pullpiri systemd 서비스 파일에 사용됩니다. 이 경로는 변경할 수 없습니다.
 - 아직 초기 버전이므로 컨테이너 시작/중지/업데이트에 시간이 오래 걸릴 수 있습니다.
 - 그 외 다른 문제가 발생할 수 있습니다.
@@ -60,16 +60,11 @@ Pullpiri는 여러 모듈로 구성되어 있습니다.
 
 ### 설치 전 준비사항
 
-필요한 패키지 설치, 방화벽 비활성화, selinux permissive 설정이 필요합니다.
+필요한 패키지 설치가 필요합니다.
 
 ```bash
-# 방화벽 비활성화
-systemctl stop firewalld
-systemctl disable firewalld
 # 패키지 설치
 dnf install git-all make gcc -y
-# selinux permissive 설정
-setenforce 0
 ```
 
 설정 변경에 대한 자세한 내용은 [설정](#pullpiri-설정)을 참고하세요.

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,7 +29,7 @@ CentOS stream (or RHEL) + Eclipse Bluechi (Maybe you will need it later)
 
 ## Make container image & Run Pullpiri
 
-Refer [Getting started](/doc/docs/getting-started.md) for launching Pullpiri.
+Refer [Getting started](/doc/guides/getting-started.md) for launching Pullpiri.
 All you have to do is run `make install` and you're ready to go.
 
 ### Check logs of containers


### PR DESCRIPTION
- Remove firewalld stop/disable and SELinux permissive instructions from getting-started guides. These were required by Bluechi (remote systemd over D-Bus/TCP), which has been removed; components now run with `--network host` and communicate over loopback, so a host firewall is not required for a single-node setup.
- Clarify the root-user recommendation with its actual rationale (systemd service registration and access to system paths like /etc, /opt).
- Fix broken documentation links after the doc/docs -> doc/guides restructure across README, guides, and examples.

refs #481